### PR TITLE
Add `download`, `grid`, `remap`, and `topo` modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,114 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -13,6 +13,7 @@ requests
 progressbar2
 pyremap >=1.4.1
 scipy
+tqdm
 xarray
 
 # build

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -12,6 +12,7 @@ netcdf4
 numpy
 requests
 progressbar2
+pyproj
 pyremap >=1.4.1
 scipy
 tqdm

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -5,6 +5,7 @@ python >=3.10
 cmocean
 esmf
 gsw
+mpas_tools >=0.36.0,<1.0.0
 matplotlib
 nco
 netcdf4

--- a/i7aof/__main__.py
+++ b/i7aof/__main__.py
@@ -4,15 +4,28 @@ Script for creating ISMIP7 Antarctic ocean forcing
 
 import argparse
 
+from mpas_tools.config import MpasConfigParser
+
 from i7aof.version import __version__
 
 
 def main():
-
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-v', '--version',
-                        action='version',
-                        version=f'ismip6_ocean_forcing {__version__}',
-                        help="Show version number and exit")
-    args = parser.parse_args()  # noqa: F841
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        '-c', '--config', nargs='*', type=str, help='Configuration file(s)'
+    )
+    parser.add_argument(
+        '-v',
+        '--version',
+        action='version',
+        version=f'ismip6_ocean_forcing {__version__}',
+        help='Show version number and exit',
+    )
+    args = parser.parse_args()
+
+    config = MpasConfigParser()
+    config.add_from_package('i7aof', 'default.cfg')
+    for config_file in args.config:
+        config.add_user_config(config_file)

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -1,0 +1,5 @@
+## config options related to the default ISMIP grid
+[ismip_grid]
+# the grid resolution in km
+dx = 8.0
+dy = 8.0

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -12,8 +12,9 @@ dy = 8000.0
 
 ## config options related to remapping
 [remap]
-# the path to the system ESMF_RegridWeightGen (if not using conda-forge)
-regrid_weight_gen = None
+# the path to the system ESMF, containing bin/ESMF_RegridWeightGen
+# (if not using conda-forge)
+esmf_path = None
 
 # the parallel executable (mpirun or srun)
 parallel_exec = mpirun

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -1,5 +1,23 @@
+## the working directory
+[workdir]
+# base working directory
+base_dir = .
+
+
 ## config options related to the default ISMIP grid
 [ismip_grid]
-# the grid resolution in km
-dx = 8.0
-dy = 8.0
+# the grid resolution in meters
+dx = 8000.0
+dy = 8000.0
+
+
+## config options related to the present-day topography dataset
+[topo]
+# the topography dataset
+dataset = bedmachine_antarctica_v3
+
+# remapping method: 'conserve' or 'bilinear'
+remap_method = conserve
+
+# the number of cores to use for remapping
+remap_cores = 4

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -10,6 +10,19 @@ base_dir = .
 dx = 8000.0
 dy = 8000.0
 
+## config options related to remapping
+[remap]
+# the path to the system ESMF_RegridWeightGen (if not using conda-forge)
+regrid_weight_gen = None
+
+# the parallel executable (mpirun or srun)
+parallel_exec = mpirun
+
+# the number of cores to use for remapping
+cores = 64
+
+# whether to include logs (one per core) from ESMF_RegridWeightGen
+include_logs = True
 
 ## config options related to the present-day topography dataset
 [topo]
@@ -18,6 +31,3 @@ dataset = bedmachine_antarctica_v3
 
 # remapping method: 'conserve' or 'bilinear'
 remap_method = conserve
-
-# the number of cores to use for remapping
-remap_cores = 4

--- a/i7aof/download.py
+++ b/i7aof/download.py
@@ -1,0 +1,79 @@
+import os
+
+import requests
+from tqdm import tqdm
+
+
+def download_file(url, dest_dir, quiet=False, overwrite=False):
+    """
+    Download a file from a given URL to a specified destination directory.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the file to download.
+    dest_dir : str
+        The destination directory where the file will be saved.
+    quiet : bool, optional
+        If True, suppress the progress bar. Default is False.
+    overwrite : bool, optional
+        If True, overwrite the file if it already exists. Default is False.
+
+    Examples
+    --------
+    >>> download_file('http://example.com/file1.txt', '/path/to/destination', quiet=True, overwrite=True)
+    """  # noqa: E501
+    if not os.path.exists(dest_dir):
+        os.makedirs(dest_dir)
+    filename = os.path.join(dest_dir, url.split('/')[-1])
+    if not overwrite and os.path.exists(filename):
+        if not quiet:
+            print(f'File {filename} already exists, skipping download.')
+        return
+    response = requests.get(url, stream=True)
+    total_size = int(response.headers.get('content-length', 0))
+    with open(filename, 'wb') as file:
+        if quiet:
+            for data in response.iter_content(chunk_size=1024):
+                file.write(data)
+        else:
+            with tqdm(
+                desc=filename,
+                total=total_size,
+                unit='B',
+                unit_scale=True,
+                unit_divisor=1024,
+            ) as bar:
+                for data in response.iter_content(chunk_size=1024):
+                    size = file.write(data)
+                    bar.update(size)
+    if not quiet:
+        print(f'Downloaded {filename}')
+
+
+def download_files(files, base_url, dest_dir, quiet=False, overwrite=False):
+    """
+    Download multiple files from a base URL to a specified destination
+    directory.
+
+    Parameters
+    ----------
+    files : list of str
+        The list of file paths to download from the base URL.
+    base_url : str
+        The base URL from which the files will be downloaded.
+    dest_dir : str
+        The destination directory where the files will be saved.
+    quiet : bool, optional
+        If True, suppress the progress bar. Default is False.
+    overwrite : bool, optional
+        If True, overwrite the files if they already exist. Default is False.
+
+    Examples
+    --------
+    >>> download_files(['file1.txt', 'subdir/file2.txt'], 'http://example.com/', '/path/to/destination', quiet=True, overwrite=True)
+    """  # noqa: E501
+    for file_path in files:
+        url = os.path.join(base_url, file_path)
+        dest_subdir = os.path.join(dest_dir, os.path.dirname(file_path))
+        download_file(url, dest_subdir, quiet, overwrite)

--- a/i7aof/grid/ismip.py
+++ b/i7aof/grid/ismip.py
@@ -44,11 +44,25 @@ def write_ismip_grid(config):
     ds.y.attrs['units'] = 'meters'
     ds.y.attrs['standard_name'] = 'projection_y_coordinate'
     ds.y.attrs['long_name'] = 'y coordinate of projection'
+    x_bnds = np.zeros((nx, 2))
+    y_bnds = np.zeros((ny, 2))
+    x_bnds[:, 0] = x - 0.5 * dx
+    x_bnds[:, 1] = x + 0.5 * dx
+    y_bnds[:, 0] = y - 0.5 * dy
+    y_bnds[:, 1] = y + 0.5 * dy
+    ds['x_bnds'] = (('x', 'nbounds'), x_bnds)
+    ds['y_bnds'] = (('y', 'nbounds'), y_bnds)
+    ds.x_bnds.attrs['units'] = 'meters'
+    ds.x_bnds.attrs['standard_name'] = 'projection_x_coordinate_bounds'
+    ds.x_bnds.attrs['long_name'] = 'x coordinate bounds of projection'
+    ds.y_bnds.attrs['units'] = 'meters'
+    ds.y_bnds.attrs['standard_name'] = 'projection_y_coordinate_bounds'
+    ds.y_bnds.attrs['long_name'] = 'y coordinate bounds of projection'
     ds.attrs['Grid'] = (
         'Datum = WGS84, earth_radius = 6378137., '
         'earth_eccentricity = 0.081819190842621, '
-        'falseeasting = -3040000., '
-        'falsenorthing = -3040000., '
+        'falseeasting = -3044000., '
+        'falsenorthing = -3044000., '
         'standard_parallel = -71., central_meridien = 0, '
         'EPSG=3031'
     )

--- a/i7aof/grid/ismip.py
+++ b/i7aof/grid/ismip.py
@@ -1,0 +1,100 @@
+import os
+
+import numpy as np
+import xarray as xr
+
+# size of the ISMIP grid in meters
+ismip_lx = 6088e3
+ismip_ly = 6088e3
+
+ismip_proj4 = 'epsg:3031'
+
+
+def write_ismip_grid(config):
+    """
+    Write the ISMIP grid to a NetCDF file.
+
+    Parameters
+    ----------
+    config : ConfigParser
+        Configuration object with grid parameters.
+    """
+    out_filename = get_ismip_grid_filename(config)
+    if os.path.exists(out_filename):
+        return
+
+    path = os.path.dirname(out_filename)
+    os.makedirs(path, exist_ok=True)
+
+    ds = xr.Dataset()
+    section = config['ismip_grid']
+    dx = section.getfloat('dx')
+    dy = section.getfloat('dy')
+    nx = np.round(ismip_lx / dx)
+    ny = np.round(ismip_ly / dy)
+    dx = ismip_lx / nx
+    dy = ismip_ly / ny
+    x = dx * np.arange(-(nx - 1) // 2, (nx - 1) // 2 + 1)
+    y = dy * np.arange(-(ny - 1) // 2, (ny - 1) // 2 + 1)
+    ds['x'] = ('x', x)
+    ds.x.attrs['units'] = 'meters'
+    ds.x.attrs['standard_name'] = 'projection_x_coordinate'
+    ds.x.attrs['long_name'] = 'x coordinate of projection'
+    ds['y'] = ('y', y)
+    ds.y.attrs['units'] = 'meters'
+    ds.y.attrs['standard_name'] = 'projection_y_coordinate'
+    ds.y.attrs['long_name'] = 'y coordinate of projection'
+    ds.attrs['Grid'] = (
+        'Datum = WGS84, earth_radius = 6378137., '
+        'earth_eccentricity = 0.081819190842621, '
+        'falseeasting = -3040000., '
+        'falsenorthing = -3040000., '
+        'standard_parallel = -71., central_meridien = 0, '
+        'EPSG=3031'
+    )
+    ds.attrs['proj'] = (
+        '+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 '
+        '+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs'
+    )
+    ds.attrs['proj4'] = ismip_proj4
+    ds.to_netcdf(out_filename)
+
+
+def get_ismip_grid_filename(config):
+    """
+    Get the ISMIP grid filename from the configuration.
+
+    Parameters
+    ----------
+    config : ConfigParser
+        Configuration object with grid parameters.
+
+    Returns
+    -------
+    str
+        The ISMIP grid filename.
+    """
+    horiz_res = get_horiz_res_string(config)
+    return os.path.join('ismip', f'ismip_{horiz_res}_grid.nc')
+
+
+def get_horiz_res_string(config):
+    """
+    Get the horizontal resolution string from the configuration.
+
+    Parameters
+    ----------
+    config : ConfigParser
+        Configuration object with grid parameters.
+
+    Returns
+    -------
+    str
+        The horizontal resolution as a string.
+    """
+    section = config['ismip_grid']
+    hres = 1e-3 * section.getfloat('dx')
+    if hres == int(hres):
+        hres = int(hres)
+    res = f'{hres}km'
+    return res

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -1,0 +1,96 @@
+import os
+
+import pyproj
+from pyremap import Remapper
+from pyremap.descriptor import ProjectionGridDescriptor
+
+from i7aof.grid.ismip import (
+    get_horiz_res_string,
+    get_ismip_grid_filename,
+    ismip_proj4,
+)
+
+
+def remap_projection_to_ismip(
+    in_filename,
+    in_mesh_name,
+    out_filename,
+    map_dir,
+    method,
+    config,
+    in_proj4='epsg:3031',
+):
+    """
+    Remap a dataset to the ISMIP grid, creating a mapping file if one does
+    not already exist.
+
+    Parameters
+    ----------
+    in_filename : str
+        The input dataset filename.
+    in_mesh_name : str
+        The name of the input mesh.
+    out_filename : str
+        The output dataset filename.
+    map_dir : str
+        The directory where the mapping file will be stored.
+    method : str
+        The remapping method to use (e.g., 'bilinear', 'nearest_s2d').
+    config : ConfigParser
+        Configuration object with remapping parameters.
+    in_proj4 : str, optional
+        The projection string for the input projection (default is
+        'epsg:3031'). This can be any string that `pyproj.Proj` accepts.
+    """
+    if os.path.exists(out_filename):
+        return
+
+    ismip_grid_filename = get_ismip_grid_filename(config)
+    horiz_res_str = get_horiz_res_string(config)
+    out_mesh_name = f'ismip_{horiz_res_str}'
+
+    cores = config.get('remap', 'cores')
+
+    esmf_path = config.get('remap', 'esmf_path')
+    if esmf_path.lower() == 'none':
+        esmf_path = None
+
+    parallel_exec = config.get('remap', 'parallel_exec')
+    if parallel_exec.lower() == 'none':
+        parallel_exec = None
+
+    include_logs = config.getboolean('remap', 'include_logs')
+
+    map_filename = os.path.join(
+        map_dir, f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
+    )
+
+    print(f'Remapping from {in_mesh_name} to ISMIP {horiz_res_str} grid...')
+
+    in_proj = pyproj.Proj(in_proj4)
+    out_proj = pyproj.Proj(ismip_proj4)
+    in_descriptor = ProjectionGridDescriptor.read(
+        projection=in_proj, fileName=in_filename, meshName=in_mesh_name
+    )
+    out_descriptor = ProjectionGridDescriptor.read(
+        projection=out_proj,
+        fileName=ismip_grid_filename,
+        meshName=out_mesh_name,
+    )
+
+    remapper = Remapper(
+        sourceDescriptor=in_descriptor,
+        destinationDescriptor=out_descriptor,
+        mappingFileName=map_filename,
+    )
+    print('  Computing remapping weights...')
+    remapper.build_mapping_file(
+        method=method,
+        mpiTasks=cores,
+        esmf_parallel_exec=parallel_exec,
+        esmf_path=esmf_path,
+        include_logs=include_logs,
+    )
+    print('  Remapping fields...')
+    remapper.remap_file(in_filename, out_filename)
+    print('  Done.')

--- a/i7aof/topo/__init__.py
+++ b/i7aof/topo/__init__.py
@@ -1,0 +1,23 @@
+from i7aof.topo.bedmachine import BedMachineAntarcticaV3
+
+
+def get_topo(config):
+    """
+    Get the topography object.
+
+    Parameters
+    ----------
+    config : mpas_tools.config.MpasConfigParser
+        Configuration options.
+
+    Returns
+    -------
+    TopoBase
+        The topography object.
+    """
+    topo_dataset = config.get('topo', 'dataset')
+    if topo_dataset == 'bedmachine_antarctica_v3':
+        topo = BedMachineAntarcticaV3(config)
+    else:
+        raise ValueError(f'Unknown topography dataset: {topo_dataset}')
+    return topo

--- a/i7aof/topo/bedmachine.py
+++ b/i7aof/topo/bedmachine.py
@@ -64,7 +64,16 @@ class BedMachineAntarcticaV3(TopoBase):
         in_mesh_name = 'bedmachine_antarctica_v3'
         out_mesh_name = f'ismip_{horiz_res_str}'
         method = config.get('topo', 'remap_method')
-        cores = config.get('topo', 'remap_cores')
+        cores = config.get('remap', 'cores')
+        regrid_weight_gen = config.get('remap', 'regrid_weight_gen')
+
+        if regrid_weight_gen.lower() == 'none':
+            regrid_weight_gen = None
+        parallel_exec = config.get('remap', 'parallel_exec')
+
+        if parallel_exec.lower() == 'none':
+            parallel_exec = None
+        include_logs = config.getboolean('remap', 'include_logs')
 
         map_filename = os.path.join(
             'topo', f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
@@ -92,7 +101,13 @@ class BedMachineAntarcticaV3(TopoBase):
             mappingFileName=map_filename,
         )
         print('  Computing remapping weights...')
-        remapper.build_mapping_file(method=method, mpiTasks=cores)
+        remapper.build_mapping_file(
+            method=method,
+            mpiTasks=cores,
+            esmf_parallel_exec=parallel_exec,
+            esmf_path=regrid_weight_gen,
+            include_logs=include_logs,
+        )
         print('  Remapping fields...')
         remapper.remap_file(in_filename, out_filename)
         print('  Done.')

--- a/i7aof/topo/bedmachine.py
+++ b/i7aof/topo/bedmachine.py
@@ -1,0 +1,98 @@
+import os
+
+import pyproj
+from pyremap import Remapper
+from pyremap.descriptor import ProjectionGridDescriptor
+
+from i7aof.grid.ismip import get_ismip_grid_filename, ismip_proj4
+from i7aof.topo.topo_base import TopoBase
+
+data_url = 'https://nsidc.org/data/nsidc-0756/versions/3'
+
+data_filename = 'BedMachineAntarctica-v3.nc'
+
+
+class BedMachineAntarcticaV3(TopoBase):
+    """
+    A class for remapping and reading Bedmachine Antarctica v3 data
+
+    See https://nsidc.org/data/nsidc-0756/versions/3 for more information
+    about Bedmachine Antarctica v3 topography data.
+    """
+
+    def download_topo(self):
+        """
+        Download the original topography file.
+        """
+        self.get_orig_topo_path()
+
+    def get_orig_topo_path(self):
+        """
+        Get the path to the original topography file before remapping
+        """
+        filename = os.path.join('topo', data_filename)
+        if not os.path.exists(filename):
+            raise FileNotFoundError(
+                f'File {filename} not found. Please download manually from '
+                f'{data_url}, as we are not authorized to download it for '
+                f'you.'
+            )
+        return filename
+
+    def get_topo_on_ismip_path(self):
+        """
+        Get the path to the topography file.
+        """
+        filename = data_filename.replace(
+            '.nc', f'_ismip_{self.horiz_res_str}.nc'
+        )
+        path = os.path.join('topo', filename)
+        return path
+
+    def remap_topo_to_ismip(self):
+        """
+        Remap the topography to the ISMIP grid."
+        """
+        config = self.config
+        horiz_res_str = self.horiz_res_str
+        in_filename = self.get_orig_topo_path()
+        out_filename = self.get_topo_on_ismip_path()
+        ismip_grid_filename = get_ismip_grid_filename(config)
+        if os.path.exists(out_filename):
+            return
+
+        in_mesh_name = 'bedmachine_antarctica_v3'
+        out_mesh_name = f'ismip_{horiz_res_str}'
+        method = config.get('topo', 'remap_method')
+        cores = config.get('topo', 'remap_cores')
+
+        map_filename = os.path.join(
+            'topo', f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
+        )
+
+        print(
+            f'Remapping Bedmachine Antarctica v3 to ISMIP '
+            f'{horiz_res_str} grid...'
+        )
+
+        in_proj = pyproj.Proj('epsg:3031')
+        out_proj = pyproj.Proj(ismip_proj4)
+        in_descriptor = ProjectionGridDescriptor.read(
+            projection=in_proj, fileName=in_filename, meshName=in_mesh_name
+        )
+        out_descriptor = ProjectionGridDescriptor.read(
+            projection=out_proj,
+            fileName=ismip_grid_filename,
+            meshName=out_mesh_name,
+        )
+
+        remapper = Remapper(
+            sourceDescriptor=in_descriptor,
+            destinationDescriptor=out_descriptor,
+            mappingFileName=map_filename,
+        )
+        print('  Computing remapping weights...')
+        remapper.build_mapping_file(method=method, mpiTasks=cores)
+        print('  Remapping fields...')
+        remapper.remap_file(in_filename, out_filename)
+        print('  Done.')

--- a/i7aof/topo/topo_base.py
+++ b/i7aof/topo/topo_base.py
@@ -1,0 +1,69 @@
+from i7aof.grid.ismip import get_horiz_res_string
+
+
+class TopoBase:
+    """
+    A base class for a topography data.
+
+    Attributes
+    ----------
+    config : mpas_tools.config.MpasConfigParser
+        Configuration options.
+
+    horiz_res_str : str
+        The horizontal resolution string (e.g. '1km', '2km', '4km', '8km').
+    """
+
+    def __init__(self, config):
+        """
+        Create a topography object.
+
+        Parameters
+        ----------
+        config : mpas_tools.config.MpasConfigParser
+            Configuration options.
+        """
+        self.config = config
+        self.horiz_res_str = get_horiz_res_string(config)
+
+    def download_topo(self):
+        """
+        Download the original topography file.
+        """
+        raise NotImplementedError(
+            'download_topo must be implemented in a subclass'
+        )
+
+    def get_orig_topo_path(self):
+        """
+        Get the path to the original topography file before remapping
+
+        Returns
+        -------
+        str
+            The path to the original topography
+        """
+        raise NotImplementedError(
+            'get_orig_topo_path must be implemented in a subclass'
+        )
+
+    def get_topo_on_ismip_path(self):
+        """
+        Get the path to the topography file.
+
+        Returns
+        -------
+        str
+            The path to the topography on the ISMIP grid
+        """
+        raise NotImplementedError(
+            'get_topo_on_ismip_path must be implemented in a subclass'
+        )
+
+    def remap_topo_to_ismip(self):
+        """
+        Remap the topography to the ISMIP grid."
+        """
+        raise NotImplementedError(
+            'remap_topo_to_ismip must be implemented in a subclass'
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "requests",
     "progressbar2",
     "scipy",
+    "tqdm",
     "xarray"
 ]
 


### PR DESCRIPTION
I'm working on topography datasets.  I had hoped that Bedmap3 would be available to try but not yet:
https://www.bas.ac.uk/project/bedmap/#data
("Coming soon.")

This merge adds a `download` module for downloading files (optionally with a progress bar).  

It also adds a `grid` subpackage with an `ismip` module for creating a grid file for the default ISMIP grid and provides functions for finding the mesh later and getting a string (e.g. `8km`) for the horizontal resolution of the mesh.

A new `remap` module adds code for remapping datasets from a projection grid (often `epsg:3031`, the same as ISMIP) to the ISMIP grid.  In the future, we will likely want to add functions for remapping from 1D and 2D lat-lon grids as well.

The new `topo` subpackage defines a `TopoBase` class with some methods for downloading and remapping topography, and querying the filenames before and after remapping.  It also defines the `BedMachineAntarcticaV3` clas that implements these methods for that particular dataset.  (We are not allowed to download BedMachine Antarctica v3 from our code, so if it isn't available, an error message tells a user where to find it and where to download it to.)

Finally, this merge adds a set of default config options in `default.cfg` that are ever growing.  A user will be able to override them by providing their own config file(s).
