### PR TITLE
A few small improvements to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ exclude = [".git",
 line-length = 79
 
 [tool.ruff.lint]
+# E501 - max line-length
 # E4 - whitespace
 # E7 - multiple-statements
 # E9 - trailing-whitespace
@@ -57,7 +58,10 @@ line-length = 79
 # W - Enable pycodestyle
 # C901 - complex-structure
 # D - Enable flake8-docstrings
-select = ["E4", "E7", "E9", "F", "B", "W", "C901"]
+select = ["E501", "E4", "E7", "E9", "F", "B", "W", "C901"]
+
+[tool.ruff.format]
+quote-style = "single"
 
 [tool.ruff.lint.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 5.


### PR DESCRIPTION
We now catch lines that are too long (unless they're explicitly tagged to ignore) and use single, rather than double quotes.