### PR TITLE
Update package for pyremap >=2.0.0

### DIFF
--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -13,7 +13,7 @@ numpy
 requests
 progressbar2
 pyproj
-pyremap >=1.4.1
+pyremap >=2.0.0,<3.0.0
 scipy
 tqdm
 xarray

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -12,18 +12,23 @@ dy = 8000.0
 
 ## config options related to remapping
 [remap]
+
+# tool for generating weight (mapping) files: 'esmf' or 'moab'
+tool = esmf
+
 # the path to the system ESMF, containing bin/ESMF_RegridWeightGen
 # (if not using conda-forge)
 esmf_path = None
+
+# the path to the system MOAB, containing bin/mbtempest
+# (if not using conda-forge)
+moab_path = None
 
 # the parallel executable (mpirun or srun)
 parallel_exec = mpirun
 
 # the number of cores to use for remapping
 cores = 64
-
-# whether to include logs (one per core) from ESMF_RegridWeightGen
-include_logs = True
 
 ## config options related to the present-day topography dataset
 [topo]

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -95,8 +95,9 @@ def remap_projection_to_ismip(
         mesh_name=out_mesh_name,
         proj_str=ismip_proj4,
     )
-    print('  Computing remapping weights...')
-    remapper.build_map(logger=logger)
+    if not os.path.exists(map_filename):
+        print('  Computing remapping weights...')
+        remapper.build_map(logger=logger)
     print('  Remapping fields...')
     remapper.ncremap(in_filename, out_filename)
     print('  Done.')

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -1,8 +1,6 @@
 import os
 
-import pyproj
 from pyremap import Remapper
-from pyremap.descriptor import ProjectionGridDescriptor
 
 from i7aof.grid.ismip import (
     get_horiz_res_string,
@@ -18,6 +16,7 @@ def remap_projection_to_ismip(
     map_dir,
     method,
     config,
+    logger,
     in_proj4='epsg:3031',
 ):
     """
@@ -38,6 +37,8 @@ def remap_projection_to_ismip(
         The remapping method to use (e.g., 'bilinear', 'nearest_s2d').
     config : ConfigParser
         Configuration object with remapping parameters.
+    logger : logging.Logger
+        Logger object for logging messages.
     in_proj4 : str, optional
         The projection string for the input projection (default is
         'epsg:3031'). This can be any string that `pyproj.Proj` accepts.
@@ -49,17 +50,20 @@ def remap_projection_to_ismip(
     horiz_res_str = get_horiz_res_string(config)
     out_mesh_name = f'ismip_{horiz_res_str}'
 
-    cores = config.get('remap', 'cores')
+    cores = config.getint('remap', 'cores')
+    remap_tool = config.get('remap', 'tool')
 
     esmf_path = config.get('remap', 'esmf_path')
     if esmf_path.lower() == 'none':
         esmf_path = None
 
+    moab_path = config.get('remap', 'moab_path')
+    if moab_path.lower() == 'none':
+        moab_path = None
+
     parallel_exec = config.get('remap', 'parallel_exec')
     if parallel_exec.lower() == 'none':
         parallel_exec = None
-
-    include_logs = config.getboolean('remap', 'include_logs')
 
     map_filename = os.path.join(
         map_dir, f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
@@ -67,30 +71,32 @@ def remap_projection_to_ismip(
 
     print(f'Remapping from {in_mesh_name} to ISMIP {horiz_res_str} grid...')
 
-    in_proj = pyproj.Proj(in_proj4)
-    out_proj = pyproj.Proj(ismip_proj4)
-    in_descriptor = ProjectionGridDescriptor.read(
-        projection=in_proj, fileName=in_filename, meshName=in_mesh_name
-    )
-    out_descriptor = ProjectionGridDescriptor.read(
-        projection=out_proj,
-        fileName=ismip_grid_filename,
-        meshName=out_mesh_name,
-    )
-
     remapper = Remapper(
-        sourceDescriptor=in_descriptor,
-        destinationDescriptor=out_descriptor,
-        mappingFileName=map_filename,
+        ntasks=cores,
+        method=method,
+        map_filename=map_filename,
+        parallel_exec=parallel_exec,
+        map_tool=remap_tool,
+        use_tmp=False,
+    )
+    remapper.src_scrip_filename = in_filename.replace('.nc', '.scrip.nc')
+    remapper.dst_scrip_filename = ismip_grid_filename.replace(
+        '.nc', '.scrip.nc'
+    )
+    remapper.esmf_path = esmf_path
+    remapper.moab_path = moab_path
+    remapper.src_from_proj(
+        filename=in_filename,
+        mesh_name=in_mesh_name,
+        proj_str=in_proj4,
+    )
+    remapper.dst_from_proj(
+        filename=ismip_grid_filename,
+        mesh_name=out_mesh_name,
+        proj_str=ismip_proj4,
     )
     print('  Computing remapping weights...')
-    remapper.build_mapping_file(
-        method=method,
-        mpiTasks=cores,
-        esmf_parallel_exec=parallel_exec,
-        esmf_path=esmf_path,
-        include_logs=include_logs,
-    )
+    remapper.build_map(logger=logger)
     print('  Remapping fields...')
-    remapper.remap_file(in_filename, out_filename)
+    remapper.ncremap(in_filename, out_filename)
     print('  Done.')

--- a/i7aof/topo/__init__.py
+++ b/i7aof/topo/__init__.py
@@ -1,7 +1,7 @@
 from i7aof.topo.bedmachine import BedMachineAntarcticaV3
 
 
-def get_topo(config):
+def get_topo(config, logger):
     """
     Get the topography object.
 
@@ -10,6 +10,9 @@ def get_topo(config):
     config : mpas_tools.config.MpasConfigParser
         Configuration options.
 
+    logger : logging.Logger
+        Logger for output from building mapping files and remapping datasets
+
     Returns
     -------
     TopoBase
@@ -17,7 +20,7 @@ def get_topo(config):
     """
     topo_dataset = config.get('topo', 'dataset')
     if topo_dataset == 'bedmachine_antarctica_v3':
-        topo = BedMachineAntarcticaV3(config)
+        topo = BedMachineAntarcticaV3(config, logger)
     else:
         raise ValueError(f'Unknown topography dataset: {topo_dataset}')
     return topo

--- a/i7aof/topo/bedmachine.py
+++ b/i7aof/topo/bedmachine.py
@@ -57,4 +57,5 @@ class BedMachineAntarcticaV3(TopoBase):
             map_dir='topo',
             method=self.config.get('topo', 'remap_method'),
             config=self.config,
+            logger=self.logger,
         )

--- a/i7aof/topo/topo_base.py
+++ b/i7aof/topo/topo_base.py
@@ -10,11 +10,14 @@ class TopoBase:
     config : mpas_tools.config.MpasConfigParser
         Configuration options.
 
+    logger : logging.Logger
+        Logger for the class.
+
     horiz_res_str : str
         The horizontal resolution string (e.g. '1km', '2km', '4km', '8km').
     """
 
-    def __init__(self, config):
+    def __init__(self, config, logger):
         """
         Create a topography object.
 
@@ -22,8 +25,11 @@ class TopoBase:
         ----------
         config : mpas_tools.config.MpasConfigParser
             Configuration options.
+        logger : logging.Logger
+            Logger for the class.
         """
         self.config = config
+        self.logger = logger
         self.horiz_res_str = get_horiz_res_string(config)
 
     def download_topo(self):


### PR DESCRIPTION
The newest release of `pyremap` introduces new syntax and API changes, so this merge updates `i7aof` accordingly.  The new `pyremap` can also accommodate remapping with the development version of MOAB, so this replaces #21.