### PR TITLE
Fix pre-commit update workfow

### DIFF
--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -9,6 +9,8 @@ on:
     # 4. Entry: Month of the year when the process will be started [1-12]
     # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
     - cron: '0 8 * * 3'
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
 
 env:
   UP_TO_DATE: false
@@ -20,17 +22,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Conda Environment
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: pre_commit_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install pre-commit and gh
+        run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
+          # permissions issue with gh 2.76.0
+          conda install -y pre-commit "gh !=2.76.0"
+          gh --version
 
       - name: Apply and commit updates
         run: |
-          git clone https://github.com/ismip/ismip7-antarctic-ocean-forcing.git update-pre-commit-deps
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
+          git clone https://github.com/E3SM-Project/mache.git update-pre-commit-deps
           cd update-pre-commit-deps
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -38,8 +54,7 @@ jobs:
           git checkout -b update-pre-commit-deps
           pre-commit autoupdate
           git add .
-          # Either there are changes, in which case we commit them, or there are no changes,
-          # in which case we can skip the push & pr-create jobs
+          # The second command will fail if no changes were present, so we ignore it
           git commit -m "Update pre-commit dependencies" \
           || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
 
@@ -57,6 +72,8 @@ jobs:
       - name: Make PR and add reviewers and labels
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
           cd update-pre-commit-deps
           gh pr create \
           --title "Update pre-commit and its dependencies" \


### PR DESCRIPTION
We are seeing issues with `gh` v2.76.0.  Working around this is easiest by using micromamba instead of the system version of `gh`.