### PR TITLE
Add a function for remapping from lat/lon to ISMIP grid

### DIFF
--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -18,6 +18,7 @@ def remap_projection_to_ismip(
     config,
     logger,
     in_proj4='epsg:3031',
+    renormalize=None,
 ):
     """
     Remap a dataset to the ISMIP grid, creating a mapping file if one does
@@ -42,6 +43,8 @@ def remap_projection_to_ismip(
     in_proj4 : str, optional
         The projection string for the input projection (default is
         'epsg:3031'). This can be any string that `pyproj.Proj` accepts.
+    renormalize : float, optional
+        If provided, a threshold to use to renormalize the data
     """
     if os.path.exists(out_filename):
         return
@@ -81,7 +84,9 @@ def remap_projection_to_ismip(
         mesh_name=out_mesh_name,
         proj_str=ismip_proj4,
     )
-    _remap_common(remapper, in_filename, out_filename, map_filename, logger)
+    _remap_common(
+        remapper, in_filename, out_filename, map_filename, logger, renormalize
+    )
 
 
 def remap_lat_lon_to_ismip(
@@ -94,6 +99,7 @@ def remap_lat_lon_to_ismip(
     logger,
     lon_var='lon',
     lat_var='lat',
+    renormalize=None,
 ):
     """
     Remap a dataset on a lat-lon grid to the ISMIP grid, creating a mapping
@@ -122,6 +128,8 @@ def remap_lat_lon_to_ismip(
     lat_var : str, optional
         The name of the latitude variable in the input dataset (default is
         'lat').
+    renormalize : float, optional
+        If provided, a threshold to use to renormalize the data
     """
     if os.path.exists(out_filename):
         return
@@ -162,7 +170,9 @@ def remap_lat_lon_to_ismip(
         mesh_name=out_mesh_name,
         proj_str=ismip_proj4,
     )
-    _remap_common(remapper, in_filename, out_filename, map_filename, logger)
+    _remap_common(
+        remapper, in_filename, out_filename, map_filename, logger, renormalize
+    )
 
 
 # --- Private helper functions below ---
@@ -228,7 +238,9 @@ def _get_remapper(
     return remapper
 
 
-def _remap_common(remapper, in_filename, out_filename, map_filename, logger):
+def _remap_common(
+    remapper, in_filename, out_filename, map_filename, logger, renormalize
+):
     """
     Common logic for building the map and remapping fields.
     """
@@ -238,5 +250,5 @@ def _remap_common(remapper, in_filename, out_filename, map_filename, logger):
         print('  Computing remapping weights...')
         remapper.build_map(logger=logger)
     print('  Remapping fields...')
-    remapper.ncremap(in_filename, out_filename)
+    remapper.ncremap(in_filename, out_filename, renormalize=renormalize)
     print('  Done.')

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -176,7 +176,7 @@ def remap_lat_lon_to_ismip(
     )
 
 
-def add_periodic_lon(ds, threshold=1e-10):
+def add_periodic_lon(ds, threshold=1e-10, lon_var='lon'):
     """
     Add a periodic longitude to a dataset if the longitude range is not
     approximately 360 degrees. This is typically needed for bilinear remapping
@@ -192,21 +192,24 @@ def add_periodic_lon(ds, threshold=1e-10):
         The threshold to determine if the longitude range is approximately
         360 degrees. Default is 1e-10.
 
+    lon_var : str, optional
+        The name of the longitude variable in the dataset. Default is 'lon'.
+
     Returns
     -------
     xarray.Dataset
         The dataset with periodic longitude added if necessary.
     """
 
-    if len(ds.lon.dims) == 1:
-        lon_dim = ds.lon.dims[0]
-        lon_range = ds.lon[-1].values - ds.lon[0].values
+    if len(ds[lon_var].dims) == 1:
+        lon_dim = ds[lon_var].dims[0]
+        lon_range = ds[lon_var][-1].values - ds[lon_var][0].values
     else:
-        assert len(ds.lon.dims) == 2
-        lon_dim = ds.lon.dims[1]
-        lon_range = ds.lon[0, -1].values - ds.lon[0, 0].values
+        assert len(ds[lon_var].dims) == 2
+        lon_dim = ds[lon_var].dims[1]
+        lon_range = ds[lon_var][0, -1].values - ds[lon_var][0, 0].values
 
-    rad = 'rad' in ds.lon.attrs.get('units', '')
+    rad = 'rad' in ds[lon_var].attrs.get('units', '')
     if rad:
         lon_range = np.rad2deg(lon_range)
 

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -216,10 +216,14 @@ def add_periodic_lon(ds, threshold=1e-10, lon_var='lon'):
     if len(ds[lon_var].dims) == 1:
         lon_dim = ds[lon_var].dims[0]
         lon_range = ds[lon_var][-1].values - ds[lon_var][0].values
-    else:
-        assert len(ds[lon_var].dims) == 2
+    elif len(ds[lon_var].dims) == 2:
         lon_dim = ds[lon_var].dims[1]
         lon_range = ds[lon_var][0, -1].values - ds[lon_var][0, 0].values
+    else:
+        raise ValueError(
+            f'Expected longitude variable "{lon_var}" to have 1 or 2 '
+            f'dimensions, but got {len(ds[lon_var].dims)}.'
+        )
 
     rad = 'rad' in ds[lon_var].attrs.get('units', '')
     if rad:

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -86,7 +86,13 @@ def remap_projection_to_ismip(
         proj_str=ismip_proj4,
     )
     _remap_common(
-        remapper, in_filename, out_filename, map_filename, logger, renormalize
+        remapper,
+        in_filename,
+        ismip_grid_filename,
+        out_filename,
+        map_filename,
+        logger,
+        renormalize,
     )
 
 
@@ -172,7 +178,13 @@ def remap_lat_lon_to_ismip(
         proj_str=ismip_proj4,
     )
     _remap_common(
-        remapper, in_filename, out_filename, map_filename, logger, renormalize
+        remapper,
+        in_filename,
+        ismip_grid_filename,
+        out_filename,
+        map_filename,
+        logger,
+        renormalize,
     )
 
 
@@ -284,13 +296,21 @@ def _get_remapper(
 
 
 def _remap_common(
-    remapper, in_filename, out_filename, map_filename, logger, renormalize
+    remapper,
+    in_filename,
+    ismip_grid_filename,
+    out_filename,
+    map_filename,
+    logger,
+    renormalize,
 ):
     """
     Common logic for building the map and remapping fields.
     """
     remapper.src_scrip_filename = in_filename.replace('.nc', '.scrip.nc')
-    # dst_scrip_filename is already set by the caller
+    remapper.dst_scrip_filename = ismip_grid_filename.replace(
+        '.nc', '.scrip.nc'
+    )
     if not os.path.exists(map_filename):
         print('  Computing remapping weights...')
         remapper.build_map(logger=logger)

--- a/i7aof/remap.py
+++ b/i7aof/remap.py
@@ -11,7 +11,7 @@ from i7aof.grid.ismip import (
 
 def remap_projection_to_ismip(
     in_filename,
-    in_mesh_name,
+    in_grid_name,
     out_filename,
     map_dir,
     method,
@@ -27,8 +27,8 @@ def remap_projection_to_ismip(
     ----------
     in_filename : str
         The input dataset filename.
-    in_mesh_name : str
-        The name of the input mesh.
+    in_grid_name : str
+        The name of the input grid.
     out_filename : str
         The output dataset filename.
     map_dir : str
@@ -46,6 +46,132 @@ def remap_projection_to_ismip(
     if os.path.exists(out_filename):
         return
 
+    (
+        ismip_grid_filename,
+        horiz_res_str,
+        out_mesh_name,
+        cores,
+        remap_tool,
+        esmf_path,
+        moab_path,
+        parallel_exec,
+    ) = _get_remap_config(config)
+    map_filename = os.path.join(
+        map_dir, f'map_{in_grid_name}_to_{out_mesh_name}_{method}.nc'
+    )
+
+    print(f'Remapping from {in_grid_name} to ISMIP {horiz_res_str} grid...')
+
+    remapper = _get_remapper(
+        cores,
+        method,
+        map_filename,
+        parallel_exec,
+        remap_tool,
+        esmf_path,
+        moab_path,
+    )
+    remapper.src_from_proj(
+        filename=in_filename,
+        mesh_name=in_grid_name,
+        proj_str=in_proj4,
+    )
+    remapper.dst_from_proj(
+        filename=ismip_grid_filename,
+        mesh_name=out_mesh_name,
+        proj_str=ismip_proj4,
+    )
+    _remap_common(remapper, in_filename, out_filename, map_filename, logger)
+
+
+def remap_lat_lon_to_ismip(
+    in_filename,
+    in_grid_name,
+    out_filename,
+    map_dir,
+    method,
+    config,
+    logger,
+    lon_var='lon',
+    lat_var='lat',
+):
+    """
+    Remap a dataset on a lat-lon grid to the ISMIP grid, creating a mapping
+    file if one does not already exist. Latitude and longitude can be 1D or
+    2D arrays.
+
+    Parameters
+    ----------
+    in_filename : str
+        The input dataset filename.
+    in_grid_name : str
+        The name of the input grid.
+    out_filename : str
+        The output dataset filename.
+    map_dir : str
+        The directory where the mapping file will be stored.
+    method : {'bilinear', 'neareststod', 'conserve'}
+        The remapping method to use.
+    config : mpas_tools.config.MpasConfigParser
+        Configuration object with remapping parameters.
+    logger : logging.Logger
+        Logger object for logging messages.
+    lon_var : str, optional
+        The name of the longitude variable in the input dataset (default is
+        'lon').
+    lat_var : str, optional
+        The name of the latitude variable in the input dataset (default is
+        'lat').
+    """
+    if os.path.exists(out_filename):
+        return
+
+    (
+        ismip_grid_filename,
+        horiz_res_str,
+        out_mesh_name,
+        cores,
+        remap_tool,
+        esmf_path,
+        moab_path,
+        parallel_exec,
+    ) = _get_remap_config(config)
+    map_filename = os.path.join(
+        map_dir, f'map_{in_grid_name}_to_{out_mesh_name}_{method}.nc'
+    )
+
+    print(f'Remapping from {in_grid_name} to ISMIP {horiz_res_str} grid...')
+
+    remapper = _get_remapper(
+        cores,
+        method,
+        map_filename,
+        parallel_exec,
+        remap_tool,
+        esmf_path,
+        moab_path,
+    )
+    remapper.src_from_lon_lat(
+        filename=in_filename,
+        mesh_name=in_grid_name,
+        lon_var=lon_var,
+        lat_var=lat_var,
+    )
+    remapper.dst_from_proj(
+        filename=ismip_grid_filename,
+        mesh_name=out_mesh_name,
+        proj_str=ismip_proj4,
+    )
+    _remap_common(remapper, in_filename, out_filename, map_filename, logger)
+
+
+# --- Private helper functions below ---
+
+
+def _get_remap_config(config):
+    """
+    Extract common remapping configuration values from config.
+    """
     ismip_grid_filename = get_ismip_grid_filename(config)
     horiz_res_str = get_horiz_res_string(config)
     out_mesh_name = f'ismip_{horiz_res_str}'
@@ -65,12 +191,30 @@ def remap_projection_to_ismip(
     if parallel_exec.lower() == 'none':
         parallel_exec = None
 
-    map_filename = os.path.join(
-        map_dir, f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
+    return (
+        ismip_grid_filename,
+        horiz_res_str,
+        out_mesh_name,
+        cores,
+        remap_tool,
+        esmf_path,
+        moab_path,
+        parallel_exec,
     )
 
-    print(f'Remapping from {in_mesh_name} to ISMIP {horiz_res_str} grid...')
 
+def _get_remapper(
+    cores,
+    method,
+    map_filename,
+    parallel_exec,
+    remap_tool,
+    esmf_path,
+    moab_path,
+):
+    """
+    Create and configure a Remapper instance with common settings.
+    """
     remapper = Remapper(
         ntasks=cores,
         method=method,
@@ -79,22 +223,17 @@ def remap_projection_to_ismip(
         map_tool=remap_tool,
         use_tmp=False,
     )
-    remapper.src_scrip_filename = in_filename.replace('.nc', '.scrip.nc')
-    remapper.dst_scrip_filename = ismip_grid_filename.replace(
-        '.nc', '.scrip.nc'
-    )
     remapper.esmf_path = esmf_path
     remapper.moab_path = moab_path
-    remapper.src_from_proj(
-        filename=in_filename,
-        mesh_name=in_mesh_name,
-        proj_str=in_proj4,
-    )
-    remapper.dst_from_proj(
-        filename=ismip_grid_filename,
-        mesh_name=out_mesh_name,
-        proj_str=ismip_proj4,
-    )
+    return remapper
+
+
+def _remap_common(remapper, in_filename, out_filename, map_filename, logger):
+    """
+    Common logic for building the map and remapping fields.
+    """
+    remapper.src_scrip_filename = in_filename.replace('.nc', '.scrip.nc')
+    # dst_scrip_filename is already set by the caller
     if not os.path.exists(map_filename):
         print('  Computing remapping weights...')
         remapper.build_map(logger=logger)

--- a/i7aof/topo/bedmachine.py
+++ b/i7aof/topo/bedmachine.py
@@ -70,7 +70,7 @@ class BedMachineAntarcticaV3(TopoBase):
         )
         remap_projection_to_ismip(
             in_filename=self.get_preprocessed_topo_path(),
-            in_mesh_name='bedmachine_antarctica_v3',
+            in_grid_name='bedmachine_antarctica_v3',
             in_proj4='epsg:3031',
             out_filename=remapped_filename,
             map_dir='topo',

--- a/i7aof/topo/bedmap.py
+++ b/i7aof/topo/bedmap.py
@@ -75,7 +75,7 @@ class Bedmap3(TopoBase):
         )
         remap_projection_to_ismip(
             in_filename=self.get_preprocessed_topo_path(),
-            in_mesh_name='bedmap3',
+            in_grid_name='bedmap3',
             in_proj4='epsg:3031',
             out_filename=remapped_filename,
             map_dir='topo',

--- a/scripts/test_remap_lat_lon.cfg
+++ b/scripts/test_remap_lat_lon.cfg
@@ -1,0 +1,23 @@
+## the working directory
+[workdir]
+# base working directory
+base_dir = /lcrc/group/e3sm/ac.xylar/test_ismip7_remap_lat_lon
+
+## CESM2-WACCM config options
+[cesm2_waccm]
+
+# size of xarray chunks in time for vertical interpolation
+vert_time_chunk = 1
+
+# size of xarray chunks in time for horizontal remapping
+horiz_time_chunk = 120
+
+# remapping method ('bilinear', 'neareststod', 'conserve')
+remap_method = bilinear
+
+# threshold for renormalization during horizontal remapping
+renorm_threshold = 1e-3
+
+# lat and lon variable names
+lat_var = lat
+lon_var = lon

--- a/scripts/test_remap_lat_lon.cfg
+++ b/scripts/test_remap_lat_lon.cfg
@@ -18,6 +18,8 @@ remap_method = bilinear
 # threshold for renormalization during horizontal remapping
 renorm_threshold = 1e-3
 
-# lat and lon variable names
+# lat and lon variable names and dimensions
 lat_var = lat
 lon_var = lon
+lat_dim = nlat
+lon_dim = nlon

--- a/scripts/test_remap_lat_lon.py
+++ b/scripts/test_remap_lat_lon.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python
+import os
+
+import numpy as np
+import xarray as xr
+from mpas_tools.config import MpasConfigParser
+from mpas_tools.logging import LoggingContext
+
+from i7aof.grid.ismip import (
+    get_ismip_grid_filename,
+    get_res_string,
+    write_ismip_grid,
+)
+from i7aof.io import write_netcdf
+from i7aof.remap import add_periodic_lon, remap_lat_lon_to_ismip
+from i7aof.vert.interp import VerticalInterpolator
+
+
+def mask(interpolator, src_filename, time_chunk):
+    ds_raw = xr.open_dataset(src_filename, decode_cf=False, decode_times=False)
+    # switch to positive up
+    lev_bnds = -ds_raw['lev_bnds']
+
+    ds = xr.open_dataset(src_filename, decode_times=False)
+    ds = ds.chunk({'time': time_chunk})
+
+    da = ds['thetao']
+
+    da_masked = interpolator.mask_and_sort(da)
+
+    ds_out = xr.Dataset()
+
+    ds_out = ds_out.assign_coords(
+        {
+            'lev': ('lev', interpolator.z_src.data),
+            'lev_bnds': (('lev', 'd2'), lev_bnds.data),
+        }
+    )
+    ds_out['lev'].attrs = interpolator.z_src.attrs
+    ds_out['lev_bnds'].attrs = lev_bnds.attrs
+
+    ds_out['thetao'] = da_masked.astype(np.float32)
+    ds_out['src_valid'] = interpolator.src_valid.astype(np.float32)
+    for var in ['lat', 'lon', 'time']:
+        ds_out[var] = ds[var]
+        var_bnds = f'{var}_bnds'
+        ds_out[var_bnds] = ds[var_bnds]
+
+    write_netcdf(ds_out, 'thetao_masked.nc', progress_bar=True)
+
+    ds_out = ds_out.isel(time=0)
+    write_netcdf(ds_out, 'thetao_time0_masked.nc', progress_bar=True)
+
+
+def interp(interpolator, ds_ismip, time_chunk):
+    # open it again to get a clean dataset
+    ds = xr.open_dataset('thetao_masked.nc', decode_times=False)
+    ds = ds.chunk({'time': time_chunk})
+    da_masked = ds['thetao']
+
+    da_interp = interpolator.interp(da_masked)
+
+    ds_out = xr.Dataset()
+    ds_out['thetao'] = da_interp.astype(np.float32)
+    ds_out['src_frac_interp'] = interpolator.src_frac_interp.astype(np.float32)
+    for var in ['lat', 'lon', 'time']:
+        ds_out[var] = ds[var]
+        var_bnds = f'{var}_bnds'
+        ds_out[var_bnds] = ds[var_bnds]
+    ds_out['z_extrap_bnds'] = ds_ismip['z_extrap_bnds']
+    ds_out = ds_out.drop_vars(['lev'])
+
+    write_netcdf(ds_out, 'thetao_interp.nc', progress_bar=True)
+
+    ds_out = ds_out.isel(time=0)
+    write_netcdf(ds_out, 'thetao_time0_interp.nc', progress_bar=True)
+
+
+def normalize(interpolator, ds_ismip, time_chunk):
+    # open it again to get a clean dataset
+    ds = xr.open_dataset('thetao_interp.nc', decode_times=False)
+    ds = ds.chunk({'time': time_chunk})
+    da_interp = ds['thetao']
+
+    da_normalized = interpolator.normalize(da_interp)
+
+    ds_out = xr.Dataset()
+    ds_out['thetao'] = da_normalized.astype(np.float32)
+    ds_out['src_frac_interp'] = interpolator.src_frac_interp.astype(np.float32)
+    for var in ['lat', 'lon', 'time']:
+        ds_out[var] = ds[var]
+        var_bnds = f'{var}_bnds'
+        ds_out[var_bnds] = ds[var_bnds]
+    ds_out['z_extrap_bnds'] = ds_ismip['z_extrap_bnds']
+
+    write_netcdf(ds_out, 'thetao_normalized.nc', progress_bar=True)
+
+    ds_out = ds_out.isel(time=0)
+    write_netcdf(ds_out, 'thetao_time0_normalized.nc', progress_bar=True)
+
+
+def vert_interp(config):
+    ds_ismip = xr.open_dataset(get_ismip_grid_filename(config))
+
+    src_filename = (
+        '/lcrc/group/e3sm/ac.xylar/ismip7/CMIP6_test_protocol/CESM2-WACCM/'
+        'historical/Omon/'
+        'thetao_Omon_CESM2-WACCM_historical_r1i1p1f1_gn_185001-201412.nc'
+    )
+
+    with xr.open_dataset(src_filename, decode_times=False) as ds:
+        src_valid = ds['thetao'].isel(time=0).notnull()
+        src_valid = src_valid.drop_vars(['time'])
+
+    time_chunk = config.getint('cesm2_waccm', 'vert_time_chunk')
+
+    interpolator = VerticalInterpolator(
+        src_valid=src_valid,
+        src_coord='lev',
+        dst_coord='z_extrap',
+        config=config,
+    )
+
+    mask(interpolator, src_filename, time_chunk)
+
+    interp(interpolator, ds_ismip, time_chunk)
+
+    normalize(interpolator, ds_ismip, time_chunk)
+
+    print(
+        "Vertical interpolation completed and saved to 'thetao_normalized.nc'."
+    )
+
+
+def remap_horiz(config, in_filename, logger):
+    ismip_res_str = get_res_string(config)
+
+    out_filename = (
+        f'thetao_Omon_CESM2-WACCM_historical_r1i1p1f1_185001-201412_'
+        f'ismip_{ismip_res_str}.nc'
+    )
+
+    tmpdir = 'tmp_remap_lat_lon'
+    os.makedirs(tmpdir, exist_ok=True)
+
+    method = config.get('cesm2_waccm', 'remap_method')
+    lat_var = config.get('cesm2_waccm', 'lat_var')
+    lon_var = config.get('cesm2_waccm', 'lon_var')
+
+    # Open dataset (but do not load into memory)
+    ds = xr.open_dataset(in_filename, chunks={'time': 1}, decode_times=False)
+
+    if method == 'bilinear':
+        # we need to add a periodic longitude value or remapping will have a
+        # seam
+        ds = add_periodic_lon(ds, threshold=1e-10)
+
+    input_mask_path = os.path.join(tmpdir, 'input_mask.nc')
+    output_mask_path = os.path.join(tmpdir, 'output_mask.nc')
+    if os.path.exists(output_mask_path):
+        ds_mask = xr.open_dataset(output_mask_path, decode_times=False)
+    else:
+        ds_mask = ds.copy()
+        ds_mask = ds_mask.drop_vars(['thetao', 'time', 'time_bnds'])
+        write_netcdf(ds_mask, input_mask_path, progress_bar=True)
+
+        # remap the mask without renormalizing
+        remap_lat_lon_to_ismip(
+            in_filename=input_mask_path,
+            in_grid_name='cesm2_waccm',
+            out_filename=output_mask_path,
+            map_dir='.',
+            method=method,
+            config=config,
+            logger=logger,
+            lon_var=lon_var,
+            lat_var=lat_var,
+        )
+        ds_mask = xr.open_dataset(output_mask_path, decode_times=False)
+
+    renorm_threshold = config.getfloat('cesm2_waccm', 'renorm_threshold')
+
+    # remap in 10-year chunks (by default)
+    chunk_size = config.getint('cesm2_waccm', 'horiz_time_chunk')
+    n_time = ds.sizes['time']
+    time_indices = np.arange(0, n_time, chunk_size)
+
+    remapped_chunks = []
+
+    for i_start in time_indices:
+        i_end = min(i_start + chunk_size, n_time)
+
+        input_chunk_path = os.path.join(tmpdir, f'input_{i_start}_{i_end}.nc')
+
+        # Remapped output path
+        output_chunk_path = os.path.join(
+            tmpdir, f'output_{i_start}_{i_end}.nc'
+        )
+        if os.path.exists(output_chunk_path):
+            print(
+                f'Skipping remapping for chunk {i_start}-{i_end} '
+                f'(already exists).'
+            )
+            # Load remapped chunk
+            remapped_chunk = xr.open_dataset(
+                output_chunk_path, chunks={'time': 1}, decode_times=False
+            )
+            remapped_chunks.append(remapped_chunk)
+            continue
+
+        # Slice dataset
+        subset = ds.isel(time=slice(i_start, i_end))
+        subset = subset.drop_vars(['src_frac_interp'])
+
+        # Write temporary input chunk
+        write_netcdf(subset, input_chunk_path, progress_bar=True)
+
+        # Run remapping
+        remap_lat_lon_to_ismip(
+            in_filename=input_chunk_path,
+            in_grid_name='cesm2_waccm',
+            out_filename=output_chunk_path,
+            map_dir='.',
+            method=method,
+            config=config,
+            logger=logger,
+            lon_var=lon_var,
+            lat_var=lat_var,
+            renormalize=renorm_threshold,
+        )
+
+        # Load remapped chunk
+        remapped_chunk = xr.open_dataset(
+            output_chunk_path, chunks={'time': 1}, decode_times=False
+        )
+        remapped_chunks.append(remapped_chunk)
+
+    # Concatenate all remapped chunks along time
+    ds_final = xr.concat(remapped_chunks, dim='time')
+    ds_final['src_frac_interp'] = ds_mask['src_frac_interp']
+
+    # Save final output
+    write_netcdf(ds_final, out_filename, progress_bar=True)
+
+    ds_final = ds_final.isel(time=0)
+    write_netcdf(ds_final, 'thetao_time0_remapped.nc', progress_bar=True)
+
+
+def main():
+    config = MpasConfigParser()
+    config.add_from_package('i7aof', 'default.cfg')
+    config.add_user_config('test_remap_lat_lon.cfg')
+
+    work_base_dir = config.get('workdir', 'base_dir')
+    os.makedirs(work_base_dir, exist_ok=True)
+    os.chdir(work_base_dir)
+
+    write_ismip_grid(config)
+
+    vert_interp_filename = 'thetao_normalized.nc'
+    if not os.path.exists(vert_interp_filename):
+        print(
+            f"Vertical interpolation file '{vert_interp_filename}' does not "
+            'exist. Running vertical interpolation...'
+        )
+        vert_interp(config)
+    else:
+        print(
+            f"Vertical interpolation file '{vert_interp_filename}' already "
+            'exists. Skipping vertical interpolation.'
+        )
+
+    with LoggingContext(__name__) as logger:
+        remap_horiz(config, vert_interp_filename, logger)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test_remap_lat_lon.py
+++ b/scripts/test_remap_lat_lon.py
@@ -146,6 +146,7 @@ def remap_horiz(config, in_filename, logger):
     method = config.get('cesm2_waccm', 'remap_method')
     lat_var = config.get('cesm2_waccm', 'lat_var')
     lon_var = config.get('cesm2_waccm', 'lon_var')
+    lon_dim = config.get('cesm2_waccm', 'lon_dim')
 
     # Open dataset (but do not load into memory)
     ds = xr.open_dataset(in_filename, chunks={'time': 1}, decode_times=False)
@@ -153,7 +154,7 @@ def remap_horiz(config, in_filename, logger):
     if method == 'bilinear':
         # we need to add a periodic longitude value or remapping will have a
         # seam
-        ds = add_periodic_lon(ds, threshold=1e-10, lon_var=lon_var)
+        ds = add_periodic_lon(ds, lon_var=lon_var, periodic_dim=lon_dim)
 
     input_mask_path = os.path.join(tmpdir, 'input_mask.nc')
     output_mask_path = os.path.join(tmpdir, 'output_mask.nc')

--- a/scripts/test_remap_lat_lon.py
+++ b/scripts/test_remap_lat_lon.py
@@ -153,7 +153,7 @@ def remap_horiz(config, in_filename, logger):
     if method == 'bilinear':
         # we need to add a periodic longitude value or remapping will have a
         # seam
-        ds = add_periodic_lon(ds, threshold=1e-10)
+        ds = add_periodic_lon(ds, threshold=1e-10, lon_var=lon_var)
 
     input_mask_path = os.path.join(tmpdir, 'input_mask.nc')
     output_mask_path = os.path.join(tmpdir, 'output_mask.nc')

--- a/scripts/test_remap_lat_lon.py
+++ b/scripts/test_remap_lat_lon.py
@@ -22,6 +22,8 @@ def mask(interpolator, src_filename, time_chunk):
     lev_bnds = -ds_raw['lev_bnds']
 
     ds = xr.open_dataset(src_filename, decode_times=False)
+    # test with 20 years of data
+    ds = ds.isel(time=slice(0, 240))
     ds = ds.chunk({'time': time_chunk})
 
     da = ds['thetao']


### PR DESCRIPTION
This pull request introduces significant enhancements to the remapping functionality, including the addition of new methods for remapping datasets, refactoring of existing code for clarity and reusability, and the addition of a new script for testing horizontal remapping. The changes improve flexibility, usability, and maintainability of the codebase. Below are the key updates grouped by theme:

### Enhancements to Remapping Functionality:
* Added a new function `remap_lat_lon_to_ismip` to handle remapping datasets on a lat-lon grid to the ISMIP grid, supporting 1D or 2D latitude and longitude arrays. This function includes optional renormalization and supports multiple remapping methods. [[1]](diffhunk://#diff-9eb891c27c03f2077def67b4f55734c3daf51af1df07428c196fe8e4fa795f68R47-R226) [[2]](diffhunk://#diff-9eb891c27c03f2077def67b4f55734c3daf51af1df07428c196fe8e4fa795f68L68-R269)
* Introduced the `add_periodic_lon` function to add a periodic longitude to datasets when the longitude range is not approximately 360 degrees, preventing seams during bilinear remapping.

### Code Refactoring and Reusability:
* Refactored `remap_projection_to_ismip` by replacing the `in_mesh_name` parameter with `in_grid_name` for clarity and consistency, and by extracting reusable helper functions (`_get_remap_config`, `_get_remapper`, `_remap_common`) to encapsulate configuration and remapping logic. [[1]](diffhunk://#diff-9eb891c27c03f2077def67b4f55734c3daf51af1df07428c196fe8e4fa795f68L14-R22) [[2]](diffhunk://#diff-9eb891c27c03f2077def67b4f55734c3daf51af1df07428c196fe8e4fa795f68L30-R33) [[3]](diffhunk://#diff-9eb891c27c03f2077def67b4f55734c3daf51af1df07428c196fe8e4fa795f68L68-R269) [[4]](diffhunk://#diff-9eb891c27c03f2077def67b4f55734c3daf51af1df07428c196fe8e4fa795f68L82-R295)
* Updated references to `in_mesh_name` in other modules to align with the new `in_grid_name` parameter. [[1]](diffhunk://#diff-981e5f6237731a52ef13b68713e4394e0e4fb869328b7cb6d366b7692b498f87L73-R73) [[2]](diffhunk://#diff-a7d5893dc975953909837bc0fdf0253801e25d3603c6d006d7610ae809dccc9fL78-R78)

### New Testing and Configuration Scripts:
* Added a new configuration file `scripts/test_remap_lat_lon.cfg` to define parameters for horizontal remapping, such as chunk sizes, remapping methods, and renormalization thresholds.
* Introduced a new script `scripts/test_remap_lat_lon.py` for testing horizontal remapping. This script includes functionality for masking, interpolating, normalizing, and remapping data in chunks, with support for periodic longitude handling and renormalization.

These changes collectively enhance the remapping capabilities, simplify the codebase, and provide tools for robust testing and configuration.
