### PR TITLE
Add extrapolation capability

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -93,8 +93,20 @@ jobs:
           conda activate base
           export ART_DIR="$(mktemp -d)"
           echo "ART_DIR=$ART_DIR" >> "$GITHUB_ENV"
+          # Pick the correct variant file for this Python version
+          VAR_GLOB="conda/variants/linux_64_python${{ matrix.python-version }}.*.yaml"
+          if compgen -G "$VAR_GLOB" > /dev/null; then
+            VARIANT=$(ls -1 $VAR_GLOB | head -n 1)
+          else
+            echo "No variant file found matching $VAR_GLOB" >&2
+            echo "Available variants:" >&2
+            ls -1 conda/variants || true
+            exit 1
+          fi
+          echo "Using variant: $VARIANT"
+
           # Build the package; produce a .conda artifact under a temp dir
-          rattler-build build -r conda/recipe.yaml -c conda-forge --output-dir "$ART_DIR"
+          rattler-build build -r conda/recipe.yaml -m "$VARIANT" --output-dir "$ART_DIR"
           if compgen -G "$ART_DIR/linux-64/*.conda" > /dev/null; then
             ARTIFACT_PATH=$(ls -1 "$ART_DIR"/linux-64/*.conda | head -n 1)
           else

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -67,27 +67,65 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v5
 
-      - name: Set up Conda Environment
+      - name: Set up Conda (Miniforge)
         uses: conda-incubator/setup-miniconda@v3
         with:
-          activate-environment: "ismip7_ci"
           miniforge-variant: Miniforge3
           miniforge-version: latest
           channels: conda-forge
           channel-priority: strict
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          use-mamba: false
 
-      - name: Install ismip7-antarctic-ocean-forcing
+      # Use default (libmamba) solver; no extra config required
+
+      - name: Install rattler-build
         run: |
-          conda create -n ismip7_dev --file dev-spec.txt \
-            python=${{ matrix.python-version }}
-          conda activate ismip7_dev
-          python -m pip install -vv --no-deps --no-build-isolation .
+          set -e -o pipefail
+          conda activate base
+          conda update -y --all
+          conda install -y -c conda-forge rattler-build
+          rattler-build --version
+
+      - name: Build conda package with rattler-build
+        run: |
+          set -e -o pipefail
+          conda activate base
+          export ART_DIR="$(mktemp -d)"
+          echo "ART_DIR=$ART_DIR" >> "$GITHUB_ENV"
+          # Build the package; produce a .conda artifact under a temp dir
+          rattler-build build -r conda/recipe.yaml -c conda-forge --output-dir "$ART_DIR"
+          if compgen -G "$ART_DIR/linux-64/*.conda" > /dev/null; then
+            ARTIFACT_PATH=$(ls -1 "$ART_DIR"/linux-64/*.conda | head -n 1)
+          else
+            echo "No .conda artifacts found in $ART_DIR" >&2
+            ls -R "$ART_DIR" || true
+            exit 1
+          fi
+          echo "ARTIFACT=$ARTIFACT_PATH" >> "$GITHUB_ENV"
+
+      - name: Create test env and install built package
+        run: |
+          set -e -o pipefail
+          # Create env installing our package from the local channel in one solve
+          conda create -y -n ismip7_test -c "file://$ART_DIR" -c conda-forge \
+            ismip7-antarctic-ocean-forcing python=${{ matrix.python-version }}
+          conda activate ismip7_test
+          # Sanity check: ensure package came from our local channel
+          conda list | grep -E '^ismip7-antarctic-ocean-forcing\s'
 
       - name: Run Tests
         run: |
-          conda activate ismip7_dev
+          set -e -o pipefail
+          conda activate ismip7_test
+          # Verify Python package entry points
           ismip7-antarctic-ocean-forcing --help
           ismip7-antarctic-remap-cmip --help
-          python -c "import i7aof.version; print(i7aof.version.__version__)"
+          ismip7-antarctic-extrap-cmip --help
+          # Verify Fortran executables are on PATH and executable
+          command -v i7aof_extrap_horizontal >/dev/null 2>&1
+          test -x "$(command -v i7aof_extrap_horizontal)"
+          command -v i7aof_extrap_vertical >/dev/null 2>&1
+          test -x "$(command -v i7aof_extrap_vertical)"
+          # Basic import/version check
+          python -c "import i7aof.version as v; print(v.__version__)"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Then, this repository can be cloned and a conda  environment can be set up with
+Then, this repository can be cloned and a conda environment can be set up with
 the required packages as follows:
 
 ```bash
@@ -36,6 +36,50 @@ python -m pip install -e . --no-deps --no-build-isolation
 pre-commit install
 ```
 
+### Fortran extrapolation executables
+
+The package includes Fortran executables that are required for the
+horizontal and vertical extrapolation steps. There is currently no
+Python-only implementation of these routines; without the executables
+the extrapolation workflow cannot be run. A conda-forge build that
+ships the executables automatically is planned, but until that
+feedstock is published you must build them locally to enable
+extrapolation.
+
+Quick start (after creating/activating the `ismip7_dev` environment above; and
+with `rattler-build` installed in your base environment):
+
+```bash
+# from repo root; use your base env's conda-bld as a local channel
+conda activate base
+LOCAL_CHANNEL=${CONDA_PREFIX}/conda-bld
+
+# remove previous local builds to avoid stale artifacts
+rm -rf ${LOCAL_CHANNEL}/*/ismip7-antarctic-ocean-forcing*.conda
+
+# build the package (writes into $LOCAL_CHANNEL)
+rattler-build build -c conda-forge -c nodefaults --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
+
+# install the compiled executables into your dev environment
+conda install -n ismip7_dev -c "$LOCAL_CHANNEL" ismip7-antarctic-ocean-forcing
+```
+
+Re-run the cleanup, build, and install commands whenever you change the Fortran
+sources.
+
+If you need to modify or experiment with the Fortran sources locally,
+an additional (lightweight) local package build step using
+`rattler-build` is required. A concise workflow and troubleshooting
+notes are documented in the developer guide: see
+`docs/dev/contributing.md` (section: "Building and testing the Fortran
+extrapolation tools locally"). The short version is: build the recipe
+into a local channel with `rattler-build`, then create your development
+environment using that channel ahead of `conda-forge`.
+
+If you skip the local Fortran build you will not be able to run the
+extrapolation step. Once the conda-forge package becomes available this
+manual build step will no longer be necessary for typical users.
+
 To use this environment, you simply run:
 ```bash
 conda activate ismip7_dev
@@ -46,7 +90,7 @@ Note: if the `conda` command is not found, `conda` was not added to your
 source ~/miniforge3/etc/profile.d/conda.sh
 conda activate
 ```
-to ge the base environment with the `conda` command.
+to get the base environment with the `conda` command.
 
 ### Developing in a new directory
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,11 @@ LOCAL_CHANNEL=${CONDA_PREFIX}/conda-bld
 # remove previous local builds to avoid stale artifacts
 rm -rf ${LOCAL_CHANNEL}/*/ismip7-antarctic-ocean-forcing*.conda
 
+# pick the right variant file for the python version you want to use, e.g.:
+VARIANT=conda/variants/linux_64_python3.13.____cp313.yaml
+
 # build the package (writes into $LOCAL_CHANNEL)
-rattler-build build -c conda-forge -c nodefaults --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
+rattler-build build -m "$VARIANT" --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
 
 # install the compiled executables into your dev environment
 conda install -n ismip7_dev -c "$LOCAL_CHANNEL" ismip7-antarctic-ocean-forcing

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configure and build Fortran tools
+pushd fortran
+mkdir -p build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_I7AOF_EXTRAP=ON
+cmake --build . --parallel ${CPU_COUNT:-2}
+cmake --install .
+popd
+
+# Install Python package (pure python; Fortran already installed to prefix)
+$PYTHON -m pip install . --no-deps -vv

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+
+context:
+  # Keep this in sync with i7aof/version.py (__version__)
+  version: "0.1.0"
+  python_min: "3.10"
+
+package:
+  name: ismip7-antarctic-ocean-forcing
+  version: ${{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 0
+  skip: win
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('fortran') }}
+    - cmake
+    - make
+    - pkg-config
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+    - netcdf-fortran
+    - libnetcdf
+  run:
+    - python >=${{ python_min }},<3.14
+    - cmocean
+    - esmf
+    - gsw
+    - inpoly
+    - mpas_tools >=1.3.1,<2.0.0
+    - matplotlib
+    - nco
+    - netcdf4
+    - numpy
+    - requests
+    - progressbar2
+    - pyproj
+    - pyremap >=2.0.0,<3.0.0
+    - pyshp
+    - scikit-fmm
+    - scipy
+    - shapely
+    - tqdm
+    - xarray
+
+tests:
+  - python:
+      pip_check: true
+      python_version: ${{ python_min }}.*
+      imports:
+        - i7aof
+  - script: |
+      # Confirm template import works and contains expected group name
+      python -c "import i7aof.extrap as ex; t=ex.load_template_text(); assert 'horizontal_extrapolation' in t"
+      # Verify executables were installed
+      test -x $PREFIX/bin/i7aof_extrap_horizontal
+      test -x $PREFIX/bin/i7aof_extrap_vertical
+
+about:
+  summary: Antarctic ocean forcing tools (ISMIP7) with Fortran extrapolation executables.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/ismip/ismip7-antarctic-ocean-forcing
+  documentation: https://github.com/ismip/ismip7-antarctic-ocean-forcing
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -67,7 +67,9 @@ tests:
 about:
   summary: Antarctic ocean forcing tools (ISMIP7) with Fortran extrapolation executables.
   license: MIT
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - fortran/LICENSE-extrap
   homepage: https://github.com/ismip/ismip7-antarctic-ocean-forcing
   documentation: https://github.com/ismip/ismip7-antarctic-ocean-forcing
 

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -35,6 +35,7 @@ requirements:
     - esmf
     - gsw
     - inpoly
+    - jinja2
     - mpas_tools >=1.3.1,<2.0.0
     - matplotlib
     - nco

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -3,7 +3,6 @@ schema_version: 1
 context:
   # Keep this in sync with i7aof/version.py (__version__)
   version: "0.1.0"
-  python_min: "3.10"
 
 package:
   name: ismip7-antarctic-ocean-forcing
@@ -19,18 +18,19 @@ build:
 requirements:
   build:
     - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
     - ${{ compiler('fortran') }}
     - cmake
     - make
     - pkg-config
   host:
-    - python ${{ python_min }}.*
+    - python
     - pip
     - setuptools
     - netcdf-fortran
     - libnetcdf
   run:
-    - python >=${{ python_min }},<3.14
+    - python
     - cmocean
     - dask
     - esmf
@@ -56,7 +56,6 @@ requirements:
 tests:
   - python:
       pip_check: true
-      python_version: ${{ python_min }}.*
       imports:
         - i7aof
   - script: |

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -32,6 +32,7 @@ requirements:
   run:
     - python >=${{ python_min }},<3.14
     - cmocean
+    - dask
     - esmf
     - gsw
     - inpoly

--- a/conda/variants/linux_64_python3.10.____cpython.yaml
+++ b/conda/variants/linux_64_python3.10.____cpython.yaml
@@ -1,0 +1,37 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+hdf5:
+- 1.14.6
+libnetcdf:
+- 4.9.3
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/conda/variants/linux_64_python3.11.____cpython.yaml
+++ b/conda/variants/linux_64_python3.11.____cpython.yaml
@@ -1,0 +1,37 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+hdf5:
+- 1.14.6
+libnetcdf:
+- 4.9.3
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/conda/variants/linux_64_python3.12.____cpython.yaml
+++ b/conda/variants/linux_64_python3.12.____cpython.yaml
@@ -1,0 +1,37 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+hdf5:
+- 1.14.6
+libnetcdf:
+- 4.9.3
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/conda/variants/linux_64_python3.13.____cp313.yaml
+++ b/conda/variants/linux_64_python3.13.____cp313.yaml
@@ -1,0 +1,37 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '14'
+hdf5:
+- 1.14.6
+libnetcdf:
+- 4.9.3
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - fortran_compiler_version

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -6,6 +6,7 @@ cmocean
 esmf
 gsw
 inpoly
+jinja2
 mpas_tools >=1.3.1,<2.0.0
 matplotlib
 nco

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -14,6 +14,7 @@ netcdf4
 numpy
 requests
 progressbar2
+dask
 pyproj
 pyremap >=2.0.0,<3.0.0
 pyshp

--- a/docs/api/i7aof.extrap.md
+++ b/docs/api/i7aof.extrap.md
@@ -1,0 +1,19 @@
+# i7aof.extrap
+
+Extrapolation utilities and workflows that drive the Fortran horizontal and vertical
+extrapolation executables for ISMIP. See {doc}`../dev/packages/extrap` for developer
+architecture and {doc}`../user/workflows` for usage notes.
+
+```{eval-rst}
+.. automodule:: i7aof.extrap
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+```{eval-rst}
+.. automodule:: i7aof.extrap.cmip
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,6 +12,7 @@ i7aof.grid
 i7aof.imbie
 i7aof.io
 i7aof.download
+i7aof.extrap
 i7aof.remap
 i7aof.topo
 i7aof.vert

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -55,8 +55,11 @@ From the repository root:
 # you could also build in any temp directory outside of the source repo
 LOCAL_CHANNEL=${CONDA_PREFIX}/conda-bld
 
+# pick the right variant file for the python version you want to use, e.g.:
+VARIANT=conda/variants/linux_64_python3.13.____cp313.yaml
+
 # Build the conda package (this reads conda/recipe.yaml)
-rattler-build build -c conda-forge -c nodefaults --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
+rattler-build build -m "$VARIANT" --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
 ```
 
 This creates a local channel containing a build of
@@ -113,8 +116,10 @@ conda activate base
 LOCAL_CHANNEL=${CONDA_PREFIX}/conda-bld
 # delete any packages you already built
 rm -rf ${LOCAL_CHANNEL}/*/ismip7-antarctic-ocean-forcing*.conda
+# pick the right variant file for the python version you want to use, e.g.:
+VARIANT=conda/variants/linux_64_python3.13.____cp313.yaml
 # build the package
-rattler-build build -c conda-forge -c nodefaults --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
+rattler-build build -m "$VARIANT" --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
 # recreate the environment
 conda create -y -n ismip7_dev -c "$LOCAL_CHANNEL" -c conda-forge --file dev-spec.txt ismip7-antarctic-ocean-forcing
 # activate the environment

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -28,3 +28,103 @@ sphinx-build -b html docs docs/_build/html
 ```
 
 Add test scripts to `scripts/` that can be used to smoke test features.
+
+## Building and testing the Fortran extrapolation tools locally
+
+The project now includes two small Fortran executables that perform
+horizontal and vertical extrapolation used by the `i7aof.extrap`
+package. There is currently no Python fallback; without these
+executables the extrapolation workflow cannot be exercised. Until a
+conda-forge package including them is published, you need to build and
+install them locally for any extrapolation development or testing.
+
+### 1. Ensure `rattler-build` base dependencies
+
+Install (once) into your *base* conda environment so you can perform
+local package builds:
+
+```bash
+conda install -n base -c conda-forge rattler-build
+```
+
+### 2. Build a local package
+
+From the repository root:
+
+```bash
+# you could also build in any temp directory outside of the source repo
+LOCAL_CHANNEL=${CONDA_PREFIX}/conda-bld
+
+# Build the conda package (this reads conda/recipe.yaml)
+rattler-build build -c conda-forge -c nodefaults --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
+```
+
+This creates a local channel containing a build of
+`ismip7-antarctic-ocean-forcing` with the compiled Fortran executables:
+
+- `i7aof_extrap_horizontal`
+- `i7aof_extrap_vertical`
+
+### 3. Create (or recreate) the dev environment including local build
+
+You can now create your development environment pulling everything from
+conda-forge except this package which will come from your local channel.
+Include the channel *before* conda-forge so it has priority.
+
+```bash
+conda create -y -n ismip7_dev -c "$LOCAL_CHANNEL" -c conda-forge --file dev-spec.txt ismip7-antarctic-ocean-forcing
+conda activate ismip7_dev
+```
+
+Then install the repo in editable mode (this keeps Python code live
+while preserving the compiled executables placed by the package):
+
+```bash
+pip install --no-deps --no-build-isolation -e .
+```
+
+To activate the code linting and formatting tools (required), run:
+
+```bash
+pre-commit install
+```
+
+### 4. Verify executable availability
+
+```bash
+which i7aof_extrap_horizontal
+which i7aof_extrap_vertical
+python -c "import i7aof.extrap as ex; print(ex.load_template_text()[:120])"
+```
+
+If the `which` commands return paths inside the active environment and
+the Python import succeeds, the setup is correct.
+
+### 5. Rebuilding after changes
+
+If you modify the Fortran sources under `fortran/`, rebuild and then
+recreate the environment with the new local build:
+
+```bash
+# make sure you're back in the base environment
+conda deactivate
+conda deactivate
+conda activate base
+LOCAL_CHANNEL=${CONDA_PREFIX}/conda-bld
+# delete any packages you already built
+rm -rf ${LOCAL_CHANNEL}/*/ismip7-antarctic-ocean-forcing*.conda
+# build the package
+rattler-build build -c conda-forge -c nodefaults --output-dir "$LOCAL_CHANNEL" -r conda/recipe.yaml
+# recreate the environment
+conda create -y -n ismip7_dev -c "$LOCAL_CHANNEL" -c conda-forge --file dev-spec.txt ismip7-antarctic-ocean-forcing
+# activate the environment
+conda activate ismip7_dev
+# install the python package in editable mode
+pip install --no-deps --no-build-isolation -e .
+```
+
+### Notes / troubleshooting
+
+- Clean previous build artifacts by removing `build/` subdirectories that
+  `rattler-build` creates under its cache (see its terminal output for paths)
+  if you suspect a stale build.

--- a/docs/dev/packages/extrap.md
+++ b/docs/dev/packages/extrap.md
@@ -1,0 +1,93 @@
+# i7aof.extrap
+
+Purpose: Orchestrate horizontal and vertical extrapolation of CMIP-derived
+ct/sa to the ISMIP grid using external Fortran executables.
+
+## Public Python API (by module)
+
+- Module: {py:mod}`i7aof.extrap`
+  - {py:func}`load_template_text() <i7aof.extrap.load_template_text>`:
+      Load the combined horizontal/vertical namelist template text.
+
+- Module: {py:mod}`i7aof.extrap.cmip`
+  - {py:func}`extrap_cmip() <i7aof.extrap.cmip.extrap_cmip>`:
+      Orchestrate per-file, per-variable extrapolation in time chunks with
+      optional parallel workers and per-chunk logs.
+
+## Required config options
+
+- `[workdir] base_dir` — required unless `workdir` arg is provided.
+- `[cmip_dataset]`
+  - `lon_var`, `lat_var`: variable/dimension names on input
+- `[extrap_cmip]`
+  - `time_chunk`: int; time chunk size for extrapolation.
+  - `num_workers`: int or 'auto'/'0'; controls process parallelism.
+
+## Outputs
+
+- Per-variable vertically extrapolated monthly files under:
+  `extrap/{model}/{scenario}/Omon/ct_sa/*ismip<res>_extrap.nc`
+- Per-chunk intermediates and logs under `*_tmp/` next to the final output:
+  - `input_<i0>_<i1>.nc` (prepared inputs)
+  - `horizontal_<i0>_<i1>.nc`, `vertical_<i0>_<i1>.nc`
+  - `logs/<var>_t<i0>-<i1>.log` containing Fortran output and Python tracebacks
+
+## Data model
+
+- Ensures `x`, `y` coordinates and retains only required variables for the
+  Fortran tools (target variable, time, x, y, and z/z_extrap).
+- Final concatenation injects ISMIP grid coordinates and related variables.
+
+## Runtime and external requirements
+
+- Core: `xarray`, `numpy`, `dask` (scheduler control), `mpas-tools` (config/logging).
+- Tools: Fortran executables `i7aof_extrap_horizontal` and `i7aof_extrap_vertical`.
+- Environment: `HDF5_USE_FILE_LOCKING=FALSE` set by default; OMP/BLAS/MKL threads
+  set to 1 per worker. `stdbuf` used for unbuffered Fortran output when available.
+
+## Usage
+
+```python
+from i7aof.extrap.cmip import extrap_cmip
+
+extrap_cmip(
+  model='CESM2-WACCM',
+  scenario='historical',
+  user_config_filename='my-config.cfg',
+  num_workers='auto',  # or an int
+)
+```
+
+CLI
+```text
+ismip7-antarctic-extrap-cmip \
+  --model CESM2-WACCM \
+  --scenario historical \
+  --config my-config.cfg \
+  --num_workers auto
+```
+
+## Internals (for maintainers)
+
+- Time chunking computed from source metadata; chunks run serially or in a
+  process pool (`spawn` start method). Each chunk writes a per-chunk input with
+  Dask `scheduler='synchronous'` for safer HDF5 writes, then runs horizontal and
+  vertical Fortran steps with unbuffered stdout/stderr captured to the same log.
+- Worker failures raise a `ChunkFailed(i0, i1, log_path, message)` that the parent
+  logs verbosely before cancelling outstanding futures. Pool crashes log
+  completed vs pending chunk indices and point to the logs directory.
+- Finalization concatenates vertical outputs and injects grid coordinates/vars.
+
+## Edge cases / validations
+
+- Missing required dims (`x`, `y`) or target variable raise clear errors.
+- Grid/field dimension mismatches raise `ValueError` in preparation phase.
+- If final output exists, the file is skipped entirely. If a chunk’s vertical
+  output exists, it won’t be recomputed (idempotent per-chunk work).
+
+## Extension points
+
+- Add support for additional variables or alternate Fortran executables.
+- Provide alternative scheduling strategies (e.g., per-node pools) or adaptive
+  chunk sizing.
+- Make faulthandler and logging verbosity configurable.

--- a/docs/dev/packages/index.md
+++ b/docs/dev/packages/index.md
@@ -7,6 +7,7 @@ Overview and deep dives into the code structure of `i7aof` packages. Each page o
 :caption: i7aof packages
 
 biascorr
+extrap
 grid
 imbie
 io

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(i7aof_extrapolation LANGUAGES Fortran)
+
+# Option to build shared libs later if refactored; currently just executables
+option(BUILD_I7AOF_EXTRAP "Build ISMIP7 Antarctic ocean forcing extrapolation tools" ON)
+if(NOT BUILD_I7AOF_EXTRAP)
+    message(STATUS "Extrapolation tools disabled (BUILD_I7AOF_EXTRAP=OFF)")
+    return()
+endif()
+
+# Allow user to specify NetCDF Fortran root
+# Tries pkg-config, then nf-config, then CMake's find_package
+
+find_package(PkgConfig QUIET)
+
+set(NC_HINTS "${NetCDF_ROOT}" "$ENV{NetCDF_ROOT}" "$ENV{NETCDF_DIR}" "$ENV{NETCDF_ROOT}" )
+list(REMOVE_DUPLICATES NC_HINTS)
+
+set(NETCDF_FORTRAN_FOUND FALSE)
+
+if(PkgConfig_FOUND)
+    pkg_check_modules(NETCDFF QUIET netcdf-fortran)
+    if(NETCDFF_FOUND)
+        set(NETCDF_FORTRAN_FOUND TRUE)
+        set(NETCDF_Fortran_INCLUDE_DIRS ${NETCDFF_INCLUDE_DIRS})
+        set(NETCDF_Fortran_LIBRARIES ${NETCDFF_LIBRARIES})
+    endif()
+endif()
+
+if(NOT NETCDF_FORTRAN_FOUND)
+    # Try nf-config (provided by many netcdf-fortran installs including conda)
+    find_program(NF_CONFIG nf-config HINTS ${NC_HINTS})
+    if(NF_CONFIG)
+        execute_process(COMMAND ${NF_CONFIG} --fflags OUTPUT_VARIABLE NF_FFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+        execute_process(COMMAND ${NF_CONFIG} --flibs  OUTPUT_VARIABLE NF_FLIBS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+        separate_arguments(NF_FFLAGS)
+        separate_arguments(NF_FLIBS)
+        add_library(netcdf_fortran_interface INTERFACE)
+        target_compile_options(netcdf_fortran_interface INTERFACE ${NF_FFLAGS})
+        target_link_libraries(netcdf_fortran_interface INTERFACE ${NF_FLIBS})
+        set(NETCDF_FORTRAN_FOUND TRUE)
+        set(NETCDF_Fortran_LIB_TARGET netcdf_fortran_interface)
+    endif()
+endif()
+
+if(NOT NETCDF_FORTRAN_FOUND)
+    # Final attempt: use CMake's FindNetCDF if available
+    find_package(NetCDF COMPONENTS Fortran)
+    if(TARGET NetCDF::NetCDF_Fortran)
+        set(NETCDF_FORTRAN_FOUND TRUE)
+        set(NETCDF_Fortran_LIB_TARGET NetCDF::NetCDF_Fortran)
+    endif()
+endif()
+
+if(NOT NETCDF_FORTRAN_FOUND)
+    message(FATAL_ERROR "Could not locate NetCDF Fortran library. Provide pkg-config file, nf-config, or CMake package.")
+endif()
+
+# Sources
+set(HORIZONTAL_SRC extrapolate_everywhere_horizontally.f90)
+set(VERTICAL_SRC   extrapolate_remaining_vertically.f90)
+
+add_executable(i7aof_extrap_horizontal ${HORIZONTAL_SRC})
+add_executable(i7aof_extrap_vertical   ${VERTICAL_SRC})
+
+# If we only have include dirs + libs variables (pkg-config path)
+if(NETCDF_Fortran_INCLUDE_DIRS)
+    target_include_directories(i7aof_extrap_horizontal PRIVATE ${NETCDF_Fortran_INCLUDE_DIRS})
+    target_include_directories(i7aof_extrap_vertical   PRIVATE ${NETCDF_Fortran_INCLUDE_DIRS})
+endif()
+
+if(NETCDF_Fortran_LIBRARIES)
+    target_link_libraries(i7aof_extrap_horizontal PRIVATE ${NETCDF_Fortran_LIBRARIES})
+    target_link_libraries(i7aof_extrap_vertical   PRIVATE ${NETCDF_Fortran_LIBRARIES})
+elseif(NETCDF_Fortran_LIB_TARGET)
+    target_link_libraries(i7aof_extrap_horizontal PRIVATE ${NETCDF_Fortran_LIB_TARGET})
+    target_link_libraries(i7aof_extrap_vertical   PRIVATE ${NETCDF_Fortran_LIB_TARGET})
+endif()
+
+# Basic compile flags (user can override with CMAKE_Fortran_FLAGS)
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    target_compile_options(i7aof_extrap_horizontal PRIVATE -O2 -fimplicit-none -Wall)
+    target_compile_options(i7aof_extrap_vertical   PRIVATE -O2 -fimplicit-none -Wall)
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+    target_compile_options(i7aof_extrap_horizontal PRIVATE -O2 -warn all)
+    target_compile_options(i7aof_extrap_vertical   PRIVATE -O2 -warn all)
+endif()
+
+install(TARGETS i7aof_extrap_horizontal i7aof_extrap_vertical
+        RUNTIME DESTINATION bin)
+
+message(STATUS "Configured i7aof_extrap_horizontal and i7aof_extrap_vertical")

--- a/fortran/LICENSE-extrap
+++ b/fortran/LICENSE-extrap
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nicolas C. Jourdain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/fortran/README.md
+++ b/fortran/README.md
@@ -1,0 +1,50 @@
+# Fortran Extrapolation Tools
+
+This directory contains the raw Fortran programs for horizontal and vertical
+extrapolation of CMIP data on the ISMIP6 grid. They are intentionally kept
+simple and currently remain outside the Python package build on PyPI. Conda
+builds (or manual builds) can produce the executables.
+
+## Building with CMake
+
+```bash
+mkdir -p build && cd build
+cmake ..
+cmake --build . --parallel
+```
+
+Upon success the executables will be located in `build/` (and installed to
+`<prefix>/bin` if you run `cmake --install . --prefix <prefix>`):
+
+* `i7aof_extrap_horizontal`
+* `i7aof_extrap_vertical`
+
+### Selecting NetCDF-Fortran
+The `CMakeLists.txt` tries these discovery methods in order:
+1. `pkg-config netcdf-fortran`
+2. `nf-config` (classic helper script)
+3. `find_package(NetCDF COMPONENTS Fortran)`
+
+If discovery fails, set one of:
+* Environment variable `NETCDF_ROOT` or `NETCDF_DIR` before configuring.
+* Run `cmake -DNetCDF_ROOT=/path/to/netcdf ..` if a CMake config is present.
+
+### Example
+```bash
+NETCDF_ROOT=$HOME/miniconda/envs/i7aof cmake ..
+cmake --build .
+```
+
+## Namelist Usage
+The programs read Fortran namelists:
+
+* Horizontal: group `&horizontal_extrapolation`
+* Vertical:   group `&vertical_extrapolation`
+
+A combined template is shipped with the Python package as
+`i7aof/extrap/namelist_template.nml.j2`.
+
+## Future Directions
+* Merge both steps into a single driver.
+* Factor out shared utilities (error handling) into modules.
+* Add lightweight regression tests with synthetic NetCDF fixtures.

--- a/fortran/README.md
+++ b/fortran/README.md
@@ -5,6 +5,10 @@ extrapolation of CMIP data on the ISMIP6 grid. They are intentionally kept
 simple and currently remain outside the Python package build on PyPI. Conda
 builds (or manual builds) can produce the executables.
 
+## License
+
+These files are covered by both `LICENSE` and `fortran/LICENSE-extrap`.
+
 ## Building with CMake
 
 ```bash

--- a/fortran/extrapolate_everywhere_horizontally.f90
+++ b/fortran/extrapolate_everywhere_horizontally.f90
@@ -242,6 +242,7 @@ status = NF90_PUT_VAR(fidM,x_ID,x); call erreur(status,.TRUE.,"putvar_x")
 !---------------------------------------------------------------------------------
 Nbasin=MAXVAL(basinNumber)+1
 write(*,*) 'Number of IMBIE2 basins : ', Nbasin
+write(*,*) 'Number of vertical levels : ', mz
 
 ! number of iteration to fill the ice shelves in each basin:
 ALLOCATE( Niter(Nbasin) )
@@ -270,6 +271,8 @@ DO kz=1,mz
   Niter(15) = 120 ! FRIS
 
   do kbasin=1,Nbasin
+
+  write(*,*) 'Step1: kz = ', kz, ', basin = ', kbasin, ' iterations = ', Niter(kbasin), ' START'
 
    do kiter=1,Niter(kbasin)
 
@@ -362,7 +365,9 @@ DO kz=1,mz
 
     var(:,:,:,:) = var_new(:,:,:,:)
 
-   enddo ! iterations
+    enddo ! iterations
+
+    write(*,*) 'Step1: kz = ', kz, ', basin = ', kbasin, ' DONE'
 
   enddo ! kbasin
 
@@ -375,6 +380,8 @@ DO kz=1,mz
   Niter(16) = 40
 
   do kbasin=1,Nbasin
+
+  write(*,*) 'Step2: kz = ', kz, ', basin = ', kbasin, ' iterations = ', Niter(kbasin), ' START'
 
    do kiter=1,Niter(kbasin)
 
@@ -466,7 +473,9 @@ DO kz=1,mz
 
     var(:,:,:,:) = var_new(:,:,:,:)
 
-   enddo ! iterations
+    enddo ! iterations
+
+    write(*,*) 'Step2: kz = ', kz, ', basin = ', kbasin, ' DONE'
 
   enddo ! kbasin
 
@@ -479,6 +488,8 @@ DO kz=1,mz
   else
     Niter2=5
   endif
+
+  write(*,*) 'Step3: kz = ', kz, ' iterations = ', Niter2, ' START'
 
   do kiter=1,Niter2
 
@@ -571,6 +582,8 @@ DO kz=1,mz
       var(:,:,:,:) = var_new(:,:,:,:)
 
   enddo ! iterations
+
+  write(*,*) 'Step3: kz = ', kz, ' DONE'
 
   !== write variable in netcdf
   status = NF90_PUT_VAR(fidM,varout_ID,var,start=(/1,1,kz,1/),count=(/mx,my,1,mtime/))

--- a/fortran/extrapolate_everywhere_horizontally.f90
+++ b/fortran/extrapolate_everywhere_horizontally.f90
@@ -12,8 +12,8 @@ INTEGER :: fidA, status, dimID_x, dimID_y, dimID_z, dimID_time, mx, my, mz, mtim
 
 CHARACTER(LEN=15) :: varnam
 
-CHARACTER(LEN=150) :: file_in, file_out, file_basin, file_topo, cal, uni, his
-CHARACTER(LEN=256) :: namelist_file
+CHARACTER(LEN=2048) :: file_in, file_out, file_basin, file_topo, cal, uni, his
+CHARACTER(LEN=2048) :: namelist_file
 
 INTEGER :: ios, narg
 
@@ -25,8 +25,6 @@ REAL*4 :: aa, bb, bbim1jjj, bbip1jjj, bbiiijm1, bbiiijp1, bbim2jjj, bbip2jjj, bb
 &                 bbim1jm1, bbim1jp1, bbip1jm1, bbip1jp1, bbim2jp1, bbim2jm1, bbip2jp1, bbip2jm1, &
 &                 bbim1jp2, bbip1jp2, bbim1jm2, bbip1jm2, bbim2jm2, bbim2jp2, bbip2jm2, bbip2jp2, &
 &                 bbim3jjj, bbip3jjj, bbiiijm3, bbiiijp3
-
-REAL*4,DIMENSION(30) :: depth
 
 REAL*4,ALLOCATABLE,DIMENSION(:) :: z, y, x
 

--- a/fortran/extrapolate_everywhere_horizontally.f90
+++ b/fortran/extrapolate_everywhere_horizontally.f90
@@ -1,0 +1,533 @@
+program modif
+
+USE netcdf
+
+IMPLICIT NONE
+
+INTEGER :: fidA, status, dimID_x, dimID_y, dimID_z, dimID_time, mx, my, mz, mtime, &
+&          time_ID, z_ID, y_ID, x_ID, varin_ID, fidM, fidB, fidT, basinNumber_ID,  &
+&          mask_ID, bed_ID, kiter, ki, kj, kz, kt, kbasin, Nbasin, mask_ocean_ID,  &
+&          varout_ID, kim1, kip1, kjm1, kjp1, kim2, kip2, kjm2, kjp2, kim3, kip3,  &
+&          kjm3, kjp3, Niter2
+
+CHARACTER(LEN=15) :: varnam
+
+CHARACTER(LEN=150) :: file_in, file_out, file_basin, file_topo, cal, uni, his
+
+REAL*4 :: miss
+
+REAL*4 :: aa, bb, bbim1jjj, bbip1jjj, bbiiijm1, bbiiijp1, bbim2jjj, bbip2jjj, bbiiijm2, bbiiijp2, &
+&                 bbim1jm1, bbim1jp1, bbip1jm1, bbip1jp1, bbim2jp1, bbim2jm1, bbip2jp1, bbip2jm1, &
+&                 bbim1jp2, bbip1jp2, bbim1jm2, bbip1jm2, bbim2jm2, bbim2jp2, bbip2jm2, bbip2jp2, &
+&                 bbim3jjj, bbip3jjj, bbiiijm3, bbiiijp3
+
+REAL*4,DIMENSION(30) :: depth
+
+REAL*4,ALLOCATABLE,DIMENSION(:) :: z, y, x
+
+REAL*8,ALLOCATABLE,DIMENSION(:) :: time
+
+INTEGER*8,ALLOCATABLE,DIMENSION(:,:) :: basinNumber
+
+REAL*4,ALLOCATABLE,DIMENSION(:,:) :: mask, bed, mask_ocean
+
+REAL*4,ALLOCATABLE,DIMENSION(:,:,:,:) :: var, var_new
+
+INTEGER,ALLOCATABLE,DIMENSION(:,:) :: mskba
+
+INTEGER,ALLOCATABLE,DIMENSION(:) :: Niter
+
+!----------------------------------------------------------------
+
+file_in  = '<file_in>'
+file_out = 'tmp_hor.nc'
+file_basin = '/data/njourdain/DATA_ISMIP6/imbie2_basin_numbers_8km_v2.nc'
+file_topo  = '/data/njourdain/DATA_ISMIP6/BedMachineAntarctica_2020-07-15_v02_8km.nc'
+
+varnam = '<var_name>'
+
+!----------------------------------------------------------------
+! Read CMIP6 data (previously interpolated to the ISMIP6 grid) :
+
+write(*,*) 'Reading ', TRIM(file_in)
+
+status = NF90_OPEN(TRIM(file_in),0,fidA); call erreur(status,.TRUE.,"read")
+
+status = NF90_INQ_DIMID(fidA,"x",dimID_x); call erreur(status,.TRUE.,"inq_dimID_x")
+status = NF90_INQ_DIMID(fidA,"y",dimID_y); call erreur(status,.TRUE.,"inq_dimID_y")
+status = NF90_INQ_DIMID(fidA,"z",dimID_z); call erreur(status,.TRUE.,"inq_dimID_z")
+status = NF90_INQ_DIMID(fidA,"time",dimID_time); call erreur(status,.TRUE.,"inq_dimID_time")
+
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_x,len=mx); call erreur(status,.TRUE.,"inq_dim_x")
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_y,len=my); call erreur(status,.TRUE.,"inq_dim_y")
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_z,len=mz); call erreur(status,.TRUE.,"inq_dim_z")
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_time,len=mtime); call erreur(status,.TRUE.,"inq_dim_time")
+
+ALLOCATE(  time(mtime)  )
+ALLOCATE(  z(mz)  )
+ALLOCATE(  y(my)  )
+ALLOCATE(  x(mx)  )
+ALLOCATE(  var(mx,my,1,mtime)  )
+ALLOCATE(  var_new(mx,my,1,mtime)  )
+
+status = NF90_INQ_VARID(fidA,"time",time_ID); call erreur(status,.TRUE.,"inq_time_ID")
+status = NF90_INQ_VARID(fidA,"z",z_ID); call erreur(status,.TRUE.,"inq_z_ID")
+status = NF90_INQ_VARID(fidA,"y",y_ID); call erreur(status,.TRUE.,"inq_y_ID")
+status = NF90_INQ_VARID(fidA,"x",x_ID); call erreur(status,.TRUE.,"inq_x_ID")
+status = NF90_INQ_VARID(fidA,TRIM(varnam),varin_ID); call erreur(status,.TRUE.,"inq_var_ID")
+
+status = NF90_GET_ATT(fidA,time_ID,'calendar',cal)     ; call erreur(status,.TRUE.,"get_att1")
+status = NF90_GET_ATT(fidA,time_ID,'units',uni)        ; call erreur(status,.TRUE.,"get_att2")
+status = NF90_GET_ATT(fidA,NF90_GLOBAL,'history',his)  ; call erreur(status,.TRUE.,"get_att3")
+
+status = NF90_GET_VAR(fidA,time_ID,time); call erreur(status,.TRUE.,"getvar_time")
+status = NF90_GET_VAR(fidA,z_ID,z); call erreur(status,.TRUE.,"getvar_z")
+status = NF90_GET_VAR(fidA,y_ID,y); call erreur(status,.TRUE.,"getvar_y")
+status = NF90_GET_VAR(fidA,x_ID,x); call erreur(status,.TRUE.,"getvar_x")
+
+!----------------------------------------------------------------
+! Reading IMBIE2 basins :
+
+write(*,*) 'Reading ', TRIM(file_basin)
+
+status = NF90_OPEN(TRIM(file_basin),0,fidB); call erreur(status,.TRUE.,"read")
+
+ALLOCATE(  basinNumber(mx,my)  )
+ALLOCATE(  mskba(mx,my)  )
+
+status = NF90_INQ_VARID(fidB,"basinNumber",basinNumber_ID); call erreur(status,.TRUE.,"inq_basinNumber_ID")
+
+status = NF90_GET_VAR(fidB,basinNumber_ID,basinNumber); call erreur(status,.TRUE.,"getvar_basinNumber")
+
+status = NF90_CLOSE(fidB); call erreur(status,.TRUE.,"close_file")
+
+
+!----------------------------------------------------------------
+! Read ice shelf mask and bed topographie
+
+write(*,*) 'Reading ', TRIM(file_topo)
+
+status = NF90_OPEN(TRIM(file_topo),0,fidT); call erreur(status,.TRUE.,"read")
+
+ALLOCATE(  mask(mx,my)  )
+ALLOCATE(  bed(mx,my)  )
+ALLOCATE(  mask_ocean(mx,my)  )
+
+status = NF90_INQ_VARID(fidT,"mask",mask_ID); call erreur(status,.TRUE.,"inq_mask_ID")
+status = NF90_INQ_VARID(fidT,"bed",bed_ID); call erreur(status,.TRUE.,"inq_bed_ID")
+status = NF90_INQ_VARID(fidT,"mask_ocean",mask_ocean_ID); call erreur(status,.TRUE.,"inq_mask_ocean_ID")
+
+status = NF90_GET_VAR(fidT,mask_ID,mask); call erreur(status,.TRUE.,"getvar_mask")
+status = NF90_GET_VAR(fidT,bed_ID,bed); call erreur(status,.TRUE.,"getvar_bed")
+status = NF90_GET_VAR(fidT,mask_ocean_ID,mask_ocean); call erreur(status,.TRUE.,"getvar_mask_ocean")
+
+status = NF90_CLOSE(fidT); call erreur(status,.TRUE.,"close_file")
+
+!-------------------------------------------------------------
+! Preparing new netcdf file with extrapolated data:
+
+write(*,*) 'Creating ', TRIM(file_out)
+
+status = NF90_CREATE(TRIM(file_out),NF90_NOCLOBBER,fidM); call erreur(status,.TRUE.,'create')
+
+status = NF90_DEF_DIM(fidM,"x",mx,dimID_x); call erreur(status,.TRUE.,"def_dimID_x")
+status = NF90_DEF_DIM(fidM,"y",my,dimID_y); call erreur(status,.TRUE.,"def_dimID_y")
+status = NF90_DEF_DIM(fidM,"z",mz,dimID_z); call erreur(status,.TRUE.,"def_dimID_z")
+status = NF90_DEF_DIM(fidM,"time",NF90_UNLIMITED,dimID_time); call erreur(status,.TRUE.,"def_dimID_time")
+
+status = NF90_DEF_VAR(fidM,"time",NF90_DOUBLE,(/dimID_time/),time_ID); call erreur(status,.TRUE.,"def_var_time_ID")
+status = NF90_DEF_VAR(fidM,"z",NF90_FLOAT,(/dimID_z/),z_ID); call erreur(status,.TRUE.,"def_var_z_ID")
+status = NF90_DEF_VAR(fidM,"y",NF90_FLOAT,(/dimID_y/),y_ID); call erreur(status,.TRUE.,"def_var_y_ID")
+status = NF90_DEF_VAR(fidM,"x",NF90_FLOAT,(/dimID_x/),x_ID); call erreur(status,.TRUE.,"def_var_x_ID")
+status = NF90_DEF_VAR(fidM,TRIM(varnam),NF90_FLOAT,(/dimID_x,dimID_y,dimID_z,dimID_time/),varout_ID); call erreur(status,.TRUE.,"def_var_var_ID")
+
+status = NF90_PUT_ATT(fidM,time_ID,"calendar",TRIM(cal)); call erreur(status,.TRUE.,"put_att_time_ID")
+status = NF90_PUT_ATT(fidM,time_ID,"units",TRIM(uni)); call erreur(status,.TRUE.,"put_att_time_ID")
+status = NF90_PUT_ATT(fidM,time_ID,"standard_name","time"); call erreur(status,.TRUE.,"put_att_time_ID")
+status = NF90_PUT_ATT(fidM,z_ID,"positive","up"); call erreur(status,.TRUE.,"put_att_z_ID")
+status = NF90_PUT_ATT(fidM,z_ID,"long_name","depth"); call erreur(status,.TRUE.,"put_att_z_ID")
+status = NF90_PUT_ATT(fidM,z_ID,"units","m"); call erreur(status,.TRUE.,"put_att_z_ID")
+status = NF90_PUT_ATT(fidM,y_ID,"long_name","y coordinate"); call erreur(status,.TRUE.,"put_att_y_ID")
+status = NF90_PUT_ATT(fidM,y_ID,"units","m"); call erreur(status,.TRUE.,"put_att_y_ID")
+status = NF90_PUT_ATT(fidM,x_ID,"long_name","x coordinate"); call erreur(status,.TRUE.,"put_att_x_ID")
+status = NF90_PUT_ATT(fidM,x_ID,"units","m"); call erreur(status,.TRUE.,"put_att_x_ID")
+
+status = NF90_PUT_ATT(fidM,varout_ID,"missing_value",miss); call erreur(status,.TRUE.,"put_att_var_ID")
+
+status = NF90_PUT_ATT(fidM,NF90_GLOBAL,"project","EU-H2020-PROTECT"); call erreur(status,.TRUE.,"att_GLO1")
+status = NF90_PUT_ATT(fidM,NF90_GLOBAL,"history",TRIM(his)); call erreur(status,.TRUE.,"att_GLO2")
+status = NF90_PUT_ATT(fidM,NF90_GLOBAL,"method","see https://github.com/nicojourdain/CMIP6_data_to_ISMIP6_grid"); call erreur(status,.TRUE.,"att_GLO3")
+
+status = NF90_ENDDEF(fidM); call erreur(status,.TRUE.,"end_definition")
+
+status = NF90_PUT_VAR(fidM,time_ID,time); call erreur(status,.TRUE.,"putvar_time")
+status = NF90_PUT_VAR(fidM,z_ID,z); call erreur(status,.TRUE.,"putvar_z")
+status = NF90_PUT_VAR(fidM,y_ID,y); call erreur(status,.TRUE.,"putvar_y")
+status = NF90_PUT_VAR(fidM,x_ID,x); call erreur(status,.TRUE.,"putvar_x")
+
+!---------------------------------------------------------------------------------
+Nbasin=MAXVAL(basinNumber)+1
+write(*,*) 'Number of IMBIE2 basins : ', Nbasin
+
+! number of iteration to fill the ice shelves in each basin:
+ALLOCATE( Niter(Nbasin) )
+
+miss=-1.e6 ! temporary missing value
+
+DO kz=1,mz
+  !write(*,*) '     kz ', kz
+
+  ! read 2d variable in netcdf
+  status = NF90_GET_VAR(fidA,varin_ID,var,start=(/1,1,kz,1/),count=(/mx,my,1,mtime/))
+  call erreur(status,.TRUE.,"get_var")
+
+  do ki=1,mx
+  do kj=1,my
+  do kt=1,mtime
+    if ( ISNAN(var(ki,kj,1,kt)) )  var(ki,kj,1,kt) = miss
+  enddo
+  enddo
+  enddo
+
+  !=== step1: interpolation in basin and only into present-day ice shelf cavities and open ocean
+  Niter(:) = 20
+  Niter(3) = 75  ! Amery
+  Niter(8) = 120 ! Ross
+  Niter(15) = 120 ! FRIS
+
+  do kbasin=1,Nbasin
+
+   do kiter=1,Niter(kbasin)
+
+    var_new(:,:,:,:) = var(:,:,:,:)
+
+    do ki=1,mx
+    do kj=1,my
+      if ( abs(var(ki,kj,1,1)) .lt. 1.e3 .and. bed(ki,kj) .lt. z(kz) .and. basinNumber(ki,kj) .eq. kbasin-1 ) then
+              mskba(ki,kj) = 1
+      else
+              mskba(ki,kj) = 0
+      endif
+    enddo
+    enddo
+
+    do ki=1,mx
+    do kj=1,my
+      ! open ocean or ice shelf point with missing data and connected to ocean neighbours
+      if ( abs(var(ki,kj,1,1)) .ge. 1.e3 .and. bed(ki,kj) .lt. z(kz) .and. basinNumber(ki,kj) .eq. kbasin-1 &
+      &    .and. ( mask(ki,kj) .gt. 0.01 .or. mask_ocean(ki,kj) .gt. 0.01 ) ) then
+
+           ! Gaussian (sigma=24km) extrapolation to contiguous neighbours (needs continuous connection to (ki,kj) ) :
+
+           kim1=MAX(ki-1, 1) ; kim2=MAX(ki-2, 1) ; kim3=MAX(ki-3, 1)
+           kip1=MIN(ki+1,mx) ; kip2=MIN(ki+2,mx) ; kip3=MIN(ki+3,mx)
+           kjm1=MAX(kj-1, 1) ; kjm2=MAX(kj-2, 1) ; kjm3=MAX(kj-3, 1)
+           kjp1=MIN(kj+1,my) ; kjp2=MIN(kj+2,my) ; kjp3=MIN(kj+3,my)
+
+           bbim1jjj = mskba(kim1,kj) * 1.e0
+           bbip1jjj = mskba(kip1,kj) * 1.e0
+           bbiiijm1 = mskba(ki,kjm1) * 1.e0
+           bbiiijp1 = mskba(ki,kjp1) * 1.e0
+           !-
+           bbim2jjj = bbim1jjj * mskba(kim2,kj)
+           bbip2jjj = bbim1jjj * mskba(kip2,kj)
+           bbiiijm2 = bbiiijm1 * mskba(ki,kjm2)
+           bbiiijp2 = bbiiijm1 * mskba(ki,kjp2)
+           !-
+           bbim1jm1 = MAX(bbim1jjj,bbiiijm1) * mskba(kim1,kjm1)
+           bbim1jp1 = MAX(bbim1jjj,bbiiijp1) * mskba(kim1,kjp1)
+           bbip1jm1 = MAX(bbip1jjj,bbiiijm1) * mskba(kip1,kjm1)
+           bbip1jp1 = MAX(bbip1jjj,bbiiijp1) * mskba(kip1,kjp1)
+           !-
+           bbim2jp1 = MAX(bbim2jjj,bbim1jp1) * mskba(kim2,kjp1)
+           bbim2jm1 = MAX(bbim2jjj,bbim1jm1) * mskba(kim2,kjm1)
+           bbip2jp1 = MAX(bbip2jjj,bbip1jp1) * mskba(kip2,kjp1)
+           bbip2jm1 = MAX(bbip2jjj,bbip1jm1) * mskba(kip2,kjm1)
+           bbim1jp2 = MAX(bbim1jp1,bbiiijp2) * mskba(kim1,kjp2)
+           bbip1jp2 = MAX(bbip1jp1,bbiiijp2) * mskba(kip1,kjp2)
+           bbim1jm2 = MAX(bbim1jm1,bbiiijm2) * mskba(kim1,kjm2)
+           bbip1jm2 = MAX(bbip1jm1,bbiiijm2) * mskba(kip1,kjm2)
+           !-
+           bbim2jm2 = MAX(bbim2jm1,bbim1jm2) * mskba(kim2,kjm2)
+           bbim2jp2 = MAX(bbim2jp1,bbim1jp2) * mskba(kim2,kjp2)
+           bbip2jm2 = MAX(bbip2jm1,bbip1jm2) * mskba(kip2,kjm2)
+           bbip2jp2 = MAX(bbip2jp1,bbip1jp2) * mskba(kip2,kjp2)
+           !-
+           bbim3jjj = bbim2jjj * mskba(kim3,kj)
+           bbip3jjj = bbim2jjj * mskba(kip3,kj)
+           bbiiijm3 = bbiiijm2 * mskba(ki,kjm3)
+           bbiiijp3 = bbiiijm2 * mskba(ki,kjp3)
+
+           bb =   ( bbim1jjj + bbip1jjj + bbiiijm1 + bbiiijp1 ) * 0.946 & ! normalised Gaussian of sigma=24km at x=8km
+           &    + ( bbim2jjj + bbip2jjj + bbiiijm2 + bbiiijp2 ) * 0.801 & !  "     "      "       "       "      x=16km
+           &    + ( bbim1jm1 + bbim1jp1 + bbip1jm1 + bbip1jp1 ) * 0.895 & !  "     "      "       "       "      x=11.3km
+           &    + ( bbim2jp1 + bbim2jm1 + bbip2jp1 + bbip2jm1 + bbim1jp2 + bbip1jp2 + bbim1jm2 + bbip1jm2 ) * 0.757 &  ! " x=17.9km
+           &    + ( bbim2jm2 + bbim2jp2 + bbip2jm2 + bbip2jp2 ) * 0.641 & !  "     "      "       "       "      x=22.6km
+           &    + ( bbim3jjj + bbip3jjj + bbiiijm3 + bbiiijp3 ) * 0.606   !  "     "      "       "       "      x=24km
+
+           if ( bb .gt. 0.1 ) then
+
+             do kt=1,mtime
+
+               aa =   (  bbim1jjj*var(kim1,kj  ,1,kt) + bbip1jjj*var(kip1,kj  ,1,kt) + bbiiijm1*var(ki  ,kjm1,1,kt) + bbiiijp1*var(ki  ,kjp1,1,kt) ) * 0.946 &
+               &    + (  bbim2jjj*var(kim2,kj  ,1,kt) + bbip2jjj*var(kip2,kj  ,1,kt) + bbiiijm2*var(ki  ,kjm2,1,kt) + bbiiijp2*var(ki  ,kjp2,1,kt) ) * 0.801 &
+               &    + (  bbim1jm1*var(kim1,kjm1,1,kt) + bbim1jp1*var(kim1,kjp1,1,kt) + bbip1jm1*var(kip1,kjm1,1,kt) + bbip1jp1*var(kip1,kjp1,1,kt) ) * 0.895 &
+               &    + (  bbim2jp1*var(kim2,kjp1,1,kt) + bbim2jm1*var(kim2,kjm1,1,kt) + bbip2jp1*var(kip2,kjp1,1,kt) + bbip2jm1*var(kip2,kjm1,1,kt)           &
+               &       + bbim1jp2*var(kim1,kjp2,1,kt) + bbip1jp2*var(kip1,kjp2,1,kt) + bbim1jm2*var(kim1,kjm2,1,kt) + bbip1jm2*var(kip1,kjm2,1,kt) ) * 0.757 &
+               &    + (  bbim2jm2*var(kim2,kjm2,1,kt) + bbim2jp2*var(kim2,kjp2,1,kt) + bbip2jm2*var(kip2,kjm2,1,kt) + bbip2jp2*var(kip2,kjp2,1,kt) ) * 0.641 &
+               &    + (  bbim3jjj*var(kim3,kj  ,1,kt) + bbip3jjj*var(kip3,kj  ,1,kt) + bbiiijm3*var(ki  ,kjm3,1,kt) + bbiiijp3*var(ki  ,kjp3,1,kt) ) * 0.606
+
+               var_new(ki,kj,1,kt) = aa / bb
+
+             enddo
+
+           endif
+      endif
+    enddo
+    enddo
+
+    var(:,:,:,:) = var_new(:,:,:,:)
+
+   enddo ! iterations
+
+  enddo ! kbasin
+
+  !=== step2: horizontal interpolation beyond present-day ice shelves (where bathy allows):
+  Niter(:) = 120
+  Niter(5:9) = 200 ! 8=Ross
+  Niter(11:12) = 40
+  Niter(14) = 40
+  Niter(15) = 200 ! FRIS
+  Niter(16) = 40
+
+  do kbasin=1,Nbasin
+
+   do kiter=1,Niter(kbasin)
+
+    var_new(:,:,:,:) = var(:,:,:,:)
+
+    do ki=1,mx
+    do kj=1,my
+      if ( abs(var(ki,kj,1,1)) .lt. 1.e3 .and. bed(ki,kj) .lt. z(kz) .and. basinNumber(ki,kj) .eq. kbasin-1 ) then
+              mskba(ki,kj) = 1
+      else
+              mskba(ki,kj) = 0
+      endif
+    enddo
+    enddo
+
+    do ki=1,mx
+    do kj=1,my
+      ! open ocean or ice shelf point with missing data and connected to ocean neighbours
+      if ( abs(var(ki,kj,1,1)) .ge. 1.e3 .and. bed(ki,kj) .lt. z(kz) .and. basinNumber(ki,kj) .eq. kbasin-1 ) then
+
+           ! Gaussian (sigma=24km) extrapolation to contiguous neighbours (needs continuous connection to (ki,kj) ) :
+
+           kim1=MAX(ki-1, 1) ; kim2=MAX(ki-2, 1) ; kim3=MAX(ki-3, 1)
+           kip1=MIN(ki+1,mx) ; kip2=MIN(ki+2,mx) ; kip3=MIN(ki+3,mx)
+           kjm1=MAX(kj-1, 1) ; kjm2=MAX(kj-2, 1) ; kjm3=MAX(kj-3, 1)
+           kjp1=MIN(kj+1,my) ; kjp2=MIN(kj+2,my) ; kjp3=MIN(kj+3,my)
+
+           bbim1jjj = mskba(kim1,kj) * 1.e0
+           bbip1jjj = mskba(kip1,kj) * 1.e0
+           bbiiijm1 = mskba(ki,kjm1) * 1.e0
+           bbiiijp1 = mskba(ki,kjp1) * 1.e0
+           !-
+           bbim2jjj = bbim1jjj * mskba(kim2,kj)
+           bbip2jjj = bbim1jjj * mskba(kip2,kj)
+           bbiiijm2 = bbiiijm1 * mskba(ki,kjm2)
+           bbiiijp2 = bbiiijm1 * mskba(ki,kjp2)
+           !-
+           bbim1jm1 = MAX(bbim1jjj,bbiiijm1) * mskba(kim1,kjm1)
+           bbim1jp1 = MAX(bbim1jjj,bbiiijp1) * mskba(kim1,kjp1)
+           bbip1jm1 = MAX(bbip1jjj,bbiiijm1) * mskba(kip1,kjm1)
+           bbip1jp1 = MAX(bbip1jjj,bbiiijp1) * mskba(kip1,kjp1)
+           !-
+           bbim2jp1 = MAX(bbim2jjj,bbim1jp1) * mskba(kim2,kjp1)
+           bbim2jm1 = MAX(bbim2jjj,bbim1jm1) * mskba(kim2,kjm1)
+           bbip2jp1 = MAX(bbip2jjj,bbip1jp1) * mskba(kip2,kjp1)
+           bbip2jm1 = MAX(bbip2jjj,bbip1jm1) * mskba(kip2,kjm1)
+           bbim1jp2 = MAX(bbim1jp1,bbiiijp2) * mskba(kim1,kjp2)
+           bbip1jp2 = MAX(bbip1jp1,bbiiijp2) * mskba(kip1,kjp2)
+           bbim1jm2 = MAX(bbim1jm1,bbiiijm2) * mskba(kim1,kjm2)
+           bbip1jm2 = MAX(bbip1jm1,bbiiijm2) * mskba(kip1,kjm2)
+           !-
+           bbim2jm2 = MAX(bbim2jm1,bbim1jm2) * mskba(kim2,kjm2)
+           bbim2jp2 = MAX(bbim2jp1,bbim1jp2) * mskba(kim2,kjp2)
+           bbip2jm2 = MAX(bbip2jm1,bbip1jm2) * mskba(kip2,kjm2)
+           bbip2jp2 = MAX(bbip2jp1,bbip1jp2) * mskba(kip2,kjp2)
+           !-
+           bbim3jjj = bbim2jjj * mskba(kim3,kj)
+           bbip3jjj = bbim2jjj * mskba(kip3,kj)
+           bbiiijm3 = bbiiijm2 * mskba(ki,kjm3)
+           bbiiijp3 = bbiiijm2 * mskba(ki,kjp3)
+
+           bb =   ( bbim1jjj + bbip1jjj + bbiiijm1 + bbiiijp1 ) * 0.946 & ! normalised Gaussian of sigma=24km at x=8km
+           &    + ( bbim2jjj + bbip2jjj + bbiiijm2 + bbiiijp2 ) * 0.801 & !  "     "      "       "       "      x=16km
+           &    + ( bbim1jm1 + bbim1jp1 + bbip1jm1 + bbip1jp1 ) * 0.895 & !  "     "      "       "       "      x=11.3km
+           &    + ( bbim2jp1 + bbim2jm1 + bbip2jp1 + bbip2jm1 + bbim1jp2 + bbip1jp2 + bbim1jm2 + bbip1jm2 ) * 0.757 &  ! " x=17.9km
+           &    + ( bbim2jm2 + bbim2jp2 + bbip2jm2 + bbip2jp2 ) * 0.641 & !  "     "      "       "       "      x=22.6km
+           &    + ( bbim3jjj + bbip3jjj + bbiiijm3 + bbiiijp3 ) * 0.606   !  "     "      "       "       "      x=24km
+
+           if ( bb .gt. 0.1 ) then
+
+             do kt=1,mtime
+
+               aa =   (  bbim1jjj*var(kim1,kj  ,1,kt) + bbip1jjj*var(kip1,kj  ,1,kt) + bbiiijm1*var(ki  ,kjm1,1,kt) + bbiiijp1*var(ki  ,kjp1,1,kt) ) * 0.946 &
+               &    + (  bbim2jjj*var(kim2,kj  ,1,kt) + bbip2jjj*var(kip2,kj  ,1,kt) + bbiiijm2*var(ki  ,kjm2,1,kt) + bbiiijp2*var(ki  ,kjp2,1,kt) ) * 0.801 &
+               &    + (  bbim1jm1*var(kim1,kjm1,1,kt) + bbim1jp1*var(kim1,kjp1,1,kt) + bbip1jm1*var(kip1,kjm1,1,kt) + bbip1jp1*var(kip1,kjp1,1,kt) ) * 0.895 &
+               &    + (  bbim2jp1*var(kim2,kjp1,1,kt) + bbim2jm1*var(kim2,kjm1,1,kt) + bbip2jp1*var(kip2,kjp1,1,kt) + bbip2jm1*var(kip2,kjm1,1,kt)           &
+               &       + bbim1jp2*var(kim1,kjp2,1,kt) + bbip1jp2*var(kip1,kjp2,1,kt) + bbim1jm2*var(kim1,kjm2,1,kt) + bbip1jm2*var(kip1,kjm2,1,kt) ) * 0.757 &
+               &    + (  bbim2jm2*var(kim2,kjm2,1,kt) + bbim2jp2*var(kim2,kjp2,1,kt) + bbip2jm2*var(kip2,kjm2,1,kt) + bbip2jp2*var(kip2,kjp2,1,kt) ) * 0.641 &
+               &    + (  bbim3jjj*var(kim3,kj  ,1,kt) + bbip3jjj*var(kip3,kj  ,1,kt) + bbiiijm3*var(ki  ,kjm3,1,kt) + bbiiijp3*var(ki  ,kjp3,1,kt) ) * 0.606
+
+               var_new(ki,kj,1,kt) = aa / bb
+
+             enddo
+
+           endif
+      endif
+    enddo
+    enddo
+
+    var(:,:,:,:) = var_new(:,:,:,:)
+
+   enddo ! iterations
+
+  enddo ! kbasin
+
+  !=== step3: horizontal interpolation everywhere AT THE SURFACE (k=2), not accounting for basins
+  !           (even if bedrock above sea level, to extrapolate downward everywhere later on).
+  !           AND extrapolation everywhere of 5 grid points to be less sensitive to BedMachine values
+  !           but not to fill deep isolated holes like Amery.
+  if ( kz.eq. 2) then ! takes 2nd level to avoid warn thin surface layer at the surface
+    Niter2=200 ! fills entire level
+  else
+    Niter2=5
+  endif
+
+  do kiter=1,Niter2
+
+      var_new(:,:,:,:) = var(:,:,:,:)
+
+      do ki=1,mx
+      do kj=1,my
+        if ( abs(var(ki,kj,1,1)) .lt. 1.e3 ) then
+                mskba(ki,kj) = 1
+        else
+                mskba(ki,kj) = 0
+        endif
+      enddo
+      enddo
+
+      do ki=1,mx
+      do kj=1,my
+        ! open ocean or ice shelf point with missing data and connected to ocean neighbours
+        if ( abs(var(ki,kj,1,1)) .ge. 1.e3 ) then
+
+             ! Gaussian (sigma=24km) extrapolation to contiguous neighbours (needs continuous connection to (ki,kj) ) :
+
+             kim1=MAX(ki-1, 1) ; kim2=MAX(ki-2, 1) ; kim3=MAX(ki-3, 1)
+             kip1=MIN(ki+1,mx) ; kip2=MIN(ki+2,mx) ; kip3=MIN(ki+3,mx)
+             kjm1=MAX(kj-1, 1) ; kjm2=MAX(kj-2, 1) ; kjm3=MAX(kj-3, 1)
+             kjp1=MIN(kj+1,my) ; kjp2=MIN(kj+2,my) ; kjp3=MIN(kj+3,my)
+
+             bbim1jjj = mskba(kim1,kj) * 1.e0
+             bbip1jjj = mskba(kip1,kj) * 1.e0
+             bbiiijm1 = mskba(ki,kjm1) * 1.e0
+             bbiiijp1 = mskba(ki,kjp1) * 1.e0
+             !-
+             bbim2jjj = bbim1jjj * mskba(kim2,kj)
+             bbip2jjj = bbim1jjj * mskba(kip2,kj)
+             bbiiijm2 = bbiiijm1 * mskba(ki,kjm2)
+             bbiiijp2 = bbiiijm1 * mskba(ki,kjp2)
+             !-
+             bbim1jm1 = MAX(bbim1jjj,bbiiijm1) * mskba(kim1,kjm1)
+             bbim1jp1 = MAX(bbim1jjj,bbiiijp1) * mskba(kim1,kjp1)
+             bbip1jm1 = MAX(bbip1jjj,bbiiijm1) * mskba(kip1,kjm1)
+             bbip1jp1 = MAX(bbip1jjj,bbiiijp1) * mskba(kip1,kjp1)
+             !-
+             bbim2jp1 = MAX(bbim2jjj,bbim1jp1) * mskba(kim2,kjp1)
+             bbim2jm1 = MAX(bbim2jjj,bbim1jm1) * mskba(kim2,kjm1)
+             bbip2jp1 = MAX(bbip2jjj,bbip1jp1) * mskba(kip2,kjp1)
+             bbip2jm1 = MAX(bbip2jjj,bbip1jm1) * mskba(kip2,kjm1)
+             bbim1jp2 = MAX(bbim1jp1,bbiiijp2) * mskba(kim1,kjp2)
+             bbip1jp2 = MAX(bbip1jp1,bbiiijp2) * mskba(kip1,kjp2)
+             bbim1jm2 = MAX(bbim1jm1,bbiiijm2) * mskba(kim1,kjm2)
+             bbip1jm2 = MAX(bbip1jm1,bbiiijm2) * mskba(kip1,kjm2)
+             !-
+             bbim2jm2 = MAX(bbim2jm1,bbim1jm2) * mskba(kim2,kjm2)
+             bbim2jp2 = MAX(bbim2jp1,bbim1jp2) * mskba(kim2,kjp2)
+             bbip2jm2 = MAX(bbip2jm1,bbip1jm2) * mskba(kip2,kjm2)
+             bbip2jp2 = MAX(bbip2jp1,bbip1jp2) * mskba(kip2,kjp2)
+             !-
+             bbim3jjj = bbim2jjj * mskba(kim3,kj)
+             bbip3jjj = bbim2jjj * mskba(kip3,kj)
+             bbiiijm3 = bbiiijm2 * mskba(ki,kjm3)
+             bbiiijp3 = bbiiijm2 * mskba(ki,kjp3)
+
+             bb =   ( bbim1jjj + bbip1jjj + bbiiijm1 + bbiiijp1 ) * 0.946 & ! normalised Gaussian of sigma=24km at x=8km
+             &    + ( bbim2jjj + bbip2jjj + bbiiijm2 + bbiiijp2 ) * 0.801 & !  "     "      "       "       "      x=16km
+             &    + ( bbim1jm1 + bbim1jp1 + bbip1jm1 + bbip1jp1 ) * 0.895 & !  "     "      "       "       "      x=11.3km
+             &    + ( bbim2jp1 + bbim2jm1 + bbip2jp1 + bbip2jm1 + bbim1jp2 + bbip1jp2 + bbim1jm2 + bbip1jm2 ) * 0.757 &  ! " x=17.9km
+             &    + ( bbim2jm2 + bbim2jp2 + bbip2jm2 + bbip2jp2 ) * 0.641 & !  "     "      "       "       "      x=22.6km
+             &    + ( bbim3jjj + bbip3jjj + bbiiijm3 + bbiiijp3 ) * 0.606   !  "     "      "       "       "      x=24km
+
+             if ( bb .gt. 0.1 ) then
+
+               do kt=1,mtime
+
+                 aa =   (  bbim1jjj*var(kim1,kj  ,1,kt) + bbip1jjj*var(kip1,kj  ,1,kt) + bbiiijm1*var(ki  ,kjm1,1,kt) + bbiiijp1*var(ki  ,kjp1,1,kt) ) * 0.946 &
+                 &    + (  bbim2jjj*var(kim2,kj  ,1,kt) + bbip2jjj*var(kip2,kj  ,1,kt) + bbiiijm2*var(ki  ,kjm2,1,kt) + bbiiijp2*var(ki  ,kjp2,1,kt) ) * 0.801 &
+                 &    + (  bbim1jm1*var(kim1,kjm1,1,kt) + bbim1jp1*var(kim1,kjp1,1,kt) + bbip1jm1*var(kip1,kjm1,1,kt) + bbip1jp1*var(kip1,kjp1,1,kt) ) * 0.895 &
+                 &    + (  bbim2jp1*var(kim2,kjp1,1,kt) + bbim2jm1*var(kim2,kjm1,1,kt) + bbip2jp1*var(kip2,kjp1,1,kt) + bbip2jm1*var(kip2,kjm1,1,kt)           &
+                 &       + bbim1jp2*var(kim1,kjp2,1,kt) + bbip1jp2*var(kip1,kjp2,1,kt) + bbim1jm2*var(kim1,kjm2,1,kt) + bbip1jm2*var(kip1,kjm2,1,kt) ) * 0.757 &
+                 &    + (  bbim2jm2*var(kim2,kjm2,1,kt) + bbim2jp2*var(kim2,kjp2,1,kt) + bbip2jm2*var(kip2,kjm2,1,kt) + bbip2jp2*var(kip2,kjp2,1,kt) ) * 0.641 &
+                 &    + (  bbim3jjj*var(kim3,kj  ,1,kt) + bbip3jjj*var(kip3,kj  ,1,kt) + bbiiijm3*var(ki  ,kjm3,1,kt) + bbiiijp3*var(ki  ,kjp3,1,kt) ) * 0.606
+
+                 var_new(ki,kj,1,kt) = aa / bb
+
+               enddo
+
+             endif
+        endif
+      enddo
+      enddo
+
+      var(:,:,:,:) = var_new(:,:,:,:)
+
+  enddo ! iterations
+
+  !== write variable in netcdf
+  status = NF90_PUT_VAR(fidM,varout_ID,var,start=(/1,1,kz,1/),count=(/mx,my,1,mtime/))
+  call erreur(status,.TRUE.,"put_var")
+
+ENDDO ! kz
+
+!---------------------
+
+status = NF90_CLOSE(fidM); call erreur(status,.TRUE.,"close_M")
+status = NF90_CLOSE(fidA); call erreur(status,.TRUE.,"close_A")
+
+end program modif
+
+
+!=====================================================================================
+SUBROUTINE erreur(iret, lstop, chaine)
+  ! pour les messages d'erreur
+  USE netcdf
+  INTEGER, INTENT(in)                     :: iret
+  LOGICAL, INTENT(in)                     :: lstop
+  CHARACTER(LEN=*), INTENT(in)            :: chaine
+  !
+  CHARACTER(LEN=80)                       :: message
+  !
+  IF ( iret .NE. 0 ) THEN
+    WRITE(*,*) 'ROUTINE: ', TRIM(chaine)
+    WRITE(*,*) 'ERREUR: ', iret
+    message=NF90_STRERROR(iret)
+    WRITE(*,*) 'CA VEUT DIRE:',TRIM(message)
+    IF ( lstop ) STOP
+  ENDIF
+  !
+END SUBROUTINE erreur

--- a/fortran/extrapolate_everywhere_horizontally.f90
+++ b/fortran/extrapolate_everywhere_horizontally.f90
@@ -14,10 +14,11 @@ CHARACTER(LEN=15) :: varnam
 
 CHARACTER(LEN=2048) :: file_in, file_out, file_basin, file_topo, cal, uni, his
 CHARACTER(LEN=2048) :: namelist_file
+CHARACTER(LEN=32)   :: z_name
 
 INTEGER :: ios, narg
 
-NAMELIST /horizontal_extrapolation/ file_in, file_out, file_basin, file_topo, varnam
+NAMELIST /horizontal_extrapolation/ file_in, file_out, file_basin, file_topo, varnam, z_name
 
 REAL*4 :: miss
 
@@ -48,6 +49,7 @@ file_out    = '__REQUIRED__'
 file_basin  = '__REQUIRED__'
 file_topo   = '__REQUIRED__'
 varnam      = '__REQUIRED__'
+z_name      = 'z'
 
 ! Determine namelist file name: first command line argument if present,
 ! otherwise fallback to a conventional filename.
@@ -106,7 +108,7 @@ status = NF90_OPEN(TRIM(file_in),0,fidA); call erreur(status,.TRUE.,"read")
 
 status = NF90_INQ_DIMID(fidA,"x",dimID_x); call erreur(status,.TRUE.,"inq_dimID_x")
 status = NF90_INQ_DIMID(fidA,"y",dimID_y); call erreur(status,.TRUE.,"inq_dimID_y")
-status = NF90_INQ_DIMID(fidA,"z",dimID_z); call erreur(status,.TRUE.,"inq_dimID_z")
+status = NF90_INQ_DIMID(fidA,TRIM(z_name),dimID_z); call erreur(status,.TRUE.,"inq_dimID_z")
 status = NF90_INQ_DIMID(fidA,"time",dimID_time); call erreur(status,.TRUE.,"inq_dimID_time")
 
 status = NF90_INQUIRE_DIMENSION(fidA,dimID_x,len=mx); call erreur(status,.TRUE.,"inq_dim_x")
@@ -122,7 +124,7 @@ ALLOCATE(  var(mx,my,1,mtime)  )
 ALLOCATE(  var_new(mx,my,1,mtime)  )
 
 status = NF90_INQ_VARID(fidA,"time",time_ID); call erreur(status,.TRUE.,"inq_time_ID")
-status = NF90_INQ_VARID(fidA,"z",z_ID); call erreur(status,.TRUE.,"inq_z_ID")
+status = NF90_INQ_VARID(fidA,TRIM(z_name),z_ID); call erreur(status,.TRUE.,"inq_z_ID")
 status = NF90_INQ_VARID(fidA,"y",y_ID); call erreur(status,.TRUE.,"inq_y_ID")
 status = NF90_INQ_VARID(fidA,"x",x_ID); call erreur(status,.TRUE.,"inq_x_ID")
 status = NF90_INQ_VARID(fidA,TRIM(varnam),varin_ID); call erreur(status,.TRUE.,"inq_var_ID")
@@ -199,11 +201,11 @@ status = NF90_CREATE(TRIM(file_out),NF90_NOCLOBBER,fidM); call erreur(status,.TR
 
 status = NF90_DEF_DIM(fidM,"x",mx,dimID_x); call erreur(status,.TRUE.,"def_dimID_x")
 status = NF90_DEF_DIM(fidM,"y",my,dimID_y); call erreur(status,.TRUE.,"def_dimID_y")
-status = NF90_DEF_DIM(fidM,"z",mz,dimID_z); call erreur(status,.TRUE.,"def_dimID_z")
+status = NF90_DEF_DIM(fidM,TRIM(z_name),mz,dimID_z); call erreur(status,.TRUE.,"def_dimID_z")
 status = NF90_DEF_DIM(fidM,"time",NF90_UNLIMITED,dimID_time); call erreur(status,.TRUE.,"def_dimID_time")
 
 status = NF90_DEF_VAR(fidM,"time",NF90_DOUBLE,(/dimID_time/),time_ID); call erreur(status,.TRUE.,"def_var_time_ID")
-status = NF90_DEF_VAR(fidM,"z",NF90_FLOAT,(/dimID_z/),z_ID); call erreur(status,.TRUE.,"def_var_z_ID")
+status = NF90_DEF_VAR(fidM,TRIM(z_name),NF90_FLOAT,(/dimID_z/),z_ID); call erreur(status,.TRUE.,"def_var_z_ID")
 status = NF90_DEF_VAR(fidM,"y",NF90_FLOAT,(/dimID_y/),y_ID); call erreur(status,.TRUE.,"def_var_y_ID")
 status = NF90_DEF_VAR(fidM,"x",NF90_FLOAT,(/dimID_x/),x_ID); call erreur(status,.TRUE.,"def_var_x_ID")
 status = NF90_DEF_VAR(fidM,TRIM(varnam),NF90_FLOAT,(/dimID_x,dimID_y,dimID_z,dimID_time/),varout_ID); call erreur(status,.TRUE.,"def_var_var_ID")

--- a/fortran/extrapolate_everywhere_horizontally.f90
+++ b/fortran/extrapolate_everywhere_horizontally.f90
@@ -587,21 +587,23 @@ end program modif
 
 
 !=====================================================================================
-SUBROUTINE erreur(iret, lstop, chaine)
-  ! pour les messages d'erreur
+SUBROUTINE erreur(iret, lstop, context)
+  ! Error reporting helper: prints NetCDF error details.
+  ! If lstop is true, terminates the program with a non-zero exit code.
   USE netcdf
-  INTEGER, INTENT(in)                     :: iret
-  LOGICAL, INTENT(in)                     :: lstop
-  CHARACTER(LEN=*), INTENT(in)            :: chaine
-  !
-  CHARACTER(LEN=80)                       :: message
-  !
+  INTEGER, INTENT(in)                  :: iret
+  LOGICAL, INTENT(in)                  :: lstop
+  CHARACTER(LEN=*), INTENT(in)         :: context
+  CHARACTER(LEN=256)                   :: message
+
   IF ( iret .NE. 0 ) THEN
-    WRITE(*,*) 'ROUTINE: ', TRIM(chaine)
-    WRITE(*,*) 'ERREUR: ', iret
-    message=NF90_STRERROR(iret)
-    WRITE(*,*) 'CA VEUT DIRE:',TRIM(message)
-    IF ( lstop ) STOP
-  ENDIF
-  !
+    WRITE(*,*) 'ROUTINE: ', TRIM(context)
+    WRITE(*,*) 'ERROR code: ', iret
+    message = NF90_STRERROR(iret)
+    WRITE(*,*) 'NETCDF message: ', TRIM(message)
+    IF ( lstop ) THEN
+      STOP 1
+    END IF
+  END IF
+
 END SUBROUTINE erreur

--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -1,0 +1,162 @@
+program modif
+
+USE netcdf
+
+IMPLICIT NONE
+
+INTEGER :: fidA, status, dimID_x, dimID_y, dimID_z, dimID_time, mx, my, mz, mtime, time_ID, &
+&          z_ID, y_ID, x_ID, var_in_ID, var_out_ID, fidM, ki, kj, kz, kt
+
+CHARACTER(LEN=10) :: varnam
+
+CHARACTER(LEN=150) :: file_in, file_out, cal, uni, his
+
+REAL*4,ALLOCATABLE,DIMENSION(:) :: z, y, x
+
+REAL*8,ALLOCATABLE,DIMENSION(:) :: time
+
+REAL*4,ALLOCATABLE,DIMENSION(:,:,:) :: var_in
+
+!---------------------------------------
+file_in  = 'tmp_hor.nc'
+file_out = '<file_out>'
+
+varnam = '<var_name>'
+
+!---------------------------------------
+! Read netcdf input file :
+
+write(*,*) 'Reading ', TRIM(file_in)
+
+status = NF90_OPEN(TRIM(file_in),0,fidA); call erreur(status,.TRUE.,"read")
+
+status = NF90_INQ_DIMID(fidA,"x",dimID_x); call erreur(status,.TRUE.,"inq_dimID_x")
+status = NF90_INQ_DIMID(fidA,"y",dimID_y); call erreur(status,.TRUE.,"inq_dimID_y")
+status = NF90_INQ_DIMID(fidA,"z",dimID_z); call erreur(status,.TRUE.,"inq_dimID_z")
+status = NF90_INQ_DIMID(fidA,"time",dimID_time); call erreur(status,.TRUE.,"inq_dimID_time")
+
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_x,len=mx); call erreur(status,.TRUE.,"inq_dim_x")
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_y,len=my); call erreur(status,.TRUE.,"inq_dim_y")
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_z,len=mz); call erreur(status,.TRUE.,"inq_dim_z")
+status = NF90_INQUIRE_DIMENSION(fidA,dimID_time,len=mtime); call erreur(status,.TRUE.,"inq_dim_time")
+
+ALLOCATE(  time(mtime)  )
+ALLOCATE(  z(mz)  )
+ALLOCATE(  y(my)  )
+ALLOCATE(  x(mx)  )
+ALLOCATE(  var_in(mx,my,mz)  )
+
+status = NF90_INQ_VARID(fidA,"time",time_ID); call erreur(status,.TRUE.,"inq_time_ID")
+status = NF90_INQ_VARID(fidA,"z",z_ID); call erreur(status,.TRUE.,"inq_z_ID")
+status = NF90_INQ_VARID(fidA,"y",y_ID); call erreur(status,.TRUE.,"inq_y_ID")
+status = NF90_INQ_VARID(fidA,"x",x_ID); call erreur(status,.TRUE.,"inq_x_ID")
+status = NF90_INQ_VARID(fidA,TRIM(varnam),var_in_ID); call erreur(status,.TRUE.,"inq_var_ID")
+
+status = NF90_GET_ATT(fidA,time_ID,'calendar',cal)     ; call erreur(status,.TRUE.,"get_att1")
+status = NF90_GET_ATT(fidA,time_ID,'units',uni)        ; call erreur(status,.TRUE.,"get_att2")
+status = NF90_GET_ATT(fidA,NF90_GLOBAL,'history',his)  ; call erreur(status,.TRUE.,"get_att3")
+
+status = NF90_GET_VAR(fidA,time_ID,time); call erreur(status,.TRUE.,"getvar_time")
+status = NF90_GET_VAR(fidA,z_ID,z); call erreur(status,.TRUE.,"getvar_z")
+status = NF90_GET_VAR(fidA,y_ID,y); call erreur(status,.TRUE.,"getvar_y")
+status = NF90_GET_VAR(fidA,x_ID,x); call erreur(status,.TRUE.,"getvar_x")
+!status = NF90_GET_VAR(fidA,var_in_ID,var_in); call erreur(status,.TRUE.,"getvar_var")
+
+!---------------------------------------
+! Writing new netcdf file :
+
+write(*,*) 'Creating ', TRIM(file_out)
+
+status = NF90_CREATE(TRIM(file_out),NF90_NOCLOBBER,fidM); call erreur(status,.TRUE.,'create')
+
+status = NF90_DEF_DIM(fidM,"x",mx,dimID_x); call erreur(status,.TRUE.,"def_dimID_x")
+status = NF90_DEF_DIM(fidM,"y",my,dimID_y); call erreur(status,.TRUE.,"def_dimID_y")
+status = NF90_DEF_DIM(fidM,"z",mz,dimID_z); call erreur(status,.TRUE.,"def_dimID_z")
+status = NF90_DEF_DIM(fidM,"time",NF90_UNLIMITED,dimID_time); call erreur(status,.TRUE.,"def_dimID_time")
+
+status = NF90_DEF_VAR(fidM,"time",NF90_DOUBLE,(/dimID_time/),time_ID); call erreur(status,.TRUE.,"def_var_time_ID")
+status = NF90_DEF_VAR(fidM,"z",NF90_FLOAT,(/dimID_z/),z_ID); call erreur(status,.TRUE.,"def_var_z_ID")
+status = NF90_DEF_VAR(fidM,"y",NF90_FLOAT,(/dimID_y/),y_ID); call erreur(status,.TRUE.,"def_var_y_ID")
+status = NF90_DEF_VAR(fidM,"x",NF90_FLOAT,(/dimID_x/),x_ID); call erreur(status,.TRUE.,"def_var_x_ID")
+status = NF90_DEF_VAR(fidM,TRIM(varnam),NF90_FLOAT,(/dimID_x,dimID_y,dimID_z,dimID_time/),var_out_ID); call erreur(status,.TRUE.,"def_var_var_ID")
+
+status = NF90_PUT_ATT(fidM,time_ID,"calendar",TRIM(cal)); call erreur(status,.TRUE.,"put_att_time_ID")
+status = NF90_PUT_ATT(fidM,time_ID,"units",TRIM(uni)); call erreur(status,.TRUE.,"put_att_time_ID")
+status = NF90_PUT_ATT(fidM,time_ID,"standard_name","time"); call erreur(status,.TRUE.,"put_att_time_ID")
+status = NF90_PUT_ATT(fidM,z_ID,"positive","up"); call erreur(status,.TRUE.,"put_att_z_ID")
+status = NF90_PUT_ATT(fidM,z_ID,"long_name","depth"); call erreur(status,.TRUE.,"put_att_z_ID")
+status = NF90_PUT_ATT(fidM,z_ID,"units","m"); call erreur(status,.TRUE.,"put_att_z_ID")
+status = NF90_PUT_ATT(fidM,y_ID,"long_name","y coordinate"); call erreur(status,.TRUE.,"put_att_y_ID")
+status = NF90_PUT_ATT(fidM,y_ID,"units","m"); call erreur(status,.TRUE.,"put_att_y_ID")
+status = NF90_PUT_ATT(fidM,x_ID,"long_name","x coordinate"); call erreur(status,.TRUE.,"put_att_x_ID")
+status = NF90_PUT_ATT(fidM,x_ID,"units","m"); call erreur(status,.TRUE.,"put_att_x_ID")
+
+status = NF90_PUT_ATT(fidM,NF90_GLOBAL,"project","EU-H2020-PROTECT"); call erreur(status,.TRUE.,"att_GLO1")
+status = NF90_PUT_ATT(fidM,NF90_GLOBAL,"history",TRIM(his)); call erreur(status,.TRUE.,"att_GLO2")
+status = NF90_PUT_ATT(fidM,NF90_GLOBAL,"method","see https://github.com/nicojourdain/CMIP6_data_to_ISMIP6_grid"); call erreur(status,.TRUE.,"att_GLO3")
+
+status = NF90_ENDDEF(fidM); call erreur(status,.TRUE.,"fin_definition")
+
+status = NF90_PUT_VAR(fidM,time_ID,time); call erreur(status,.TRUE.,"var_time_ID")
+status = NF90_PUT_VAR(fidM,z_ID,z); call erreur(status,.TRUE.,"var_z_ID")
+status = NF90_PUT_VAR(fidM,y_ID,y); call erreur(status,.TRUE.,"var_y_ID")
+status = NF90_PUT_VAR(fidM,x_ID,x); call erreur(status,.TRUE.,"var_x_ID")
+
+!----------------------------------------------------------------------------------------
+! Extrapolating vertically from kz=2 :
+!
+DO kt=1,mtime
+
+  status = NF90_GET_VAR(fidA,var_in_ID,var_in,start=(/1,1,1,kt/),count=(/mx,my,mz,1/))
+  call erreur(status,.TRUE.,"getvar_in")
+
+  do ki=1,mx
+  do kj=1,my
+    if ( abs(var_in(ki,kj,1)) .gt. 1.e3 .and. abs(var_in(ki,kj,2)) .lt. 1.e3 ) then
+       var_in(ki,kj,1) = var_in(ki,kj,2)
+    endif
+  enddo
+  enddo
+
+  DO kz=3,mz
+    do ki=1,mx
+    do kj=1,my
+      if ( abs(var_in(ki,kj,kz)) .gt. 1.e3 .and. abs(var_in(ki,kj,kz-1)) .lt. 1.e3 ) then
+         var_in(ki,kj,kz) = var_in(ki,kj,kz-1)
+      endif
+    enddo
+    enddo
+  ENDDO
+
+  status = NF90_PUT_VAR(fidM,var_out_ID,var_in,start=(/1,1,1,kt/),count=(/mx,my,mz,1/))
+  call erreur(status,.TRUE.,"putvar_out")
+
+ENDDO
+
+!----------------------------------------------------------------------------------------
+
+status = NF90_CLOSE(fidA); call erreur(status,.TRUE.,"close_file")
+status = NF90_CLOSE(fidM); call erreur(status,.TRUE.,"final")
+
+end program modif
+
+
+
+SUBROUTINE erreur(iret, lstop, chaine)
+  ! pour les messages d'erreur
+  USE netcdf
+  INTEGER, INTENT(in)                     :: iret
+  LOGICAL, INTENT(in)                     :: lstop
+  CHARACTER(LEN=*), INTENT(in)            :: chaine
+  !
+  CHARACTER(LEN=80)                       :: message
+  !
+  IF ( iret .NE. 0 ) THEN
+    WRITE(*,*) 'ROUTINE: ', TRIM(chaine)
+    WRITE(*,*) 'ERREUR: ', iret
+    message=NF90_STRERROR(iret)
+    WRITE(*,*) 'CA VEUT DIRE:',TRIM(message)
+    IF ( lstop ) STOP
+  ENDIF
+  !
+END SUBROUTINE erreur

--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -171,6 +171,10 @@ status = NF90_PUT_VAR(fidM,x_ID,x); call erreur(status,.TRUE.,"var_x_ID")
 !
 DO kt=1,mtime
 
+  if ( MOD(kt, 12) == 1 ) then
+    write(*,*) 'Vertical: processing time index kt = ', kt, ' of ', mtime
+  end if
+
   status = NF90_GET_VAR(fidA,var_in_ID,var_in,start=(/1,1,1,kt/),count=(/mx,my,mz,1/))
   call erreur(status,.TRUE.,"getvar_in")
 

--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -171,9 +171,7 @@ status = NF90_PUT_VAR(fidM,x_ID,x); call erreur(status,.TRUE.,"var_x_ID")
 !
 DO kt=1,mtime
 
-  if ( MOD(kt, 12) == 1 ) then
-    write(*,*) 'Vertical: processing time index kt = ', kt, ' of ', mtime
-  end if
+  write(*,*) 'Vertical: processing time index kt = ', kt, ' of ', mtime
 
   status = NF90_GET_VAR(fidA,var_in_ID,var_in,start=(/1,1,1,kt/),count=(/mx,my,mz,1/))
   call erreur(status,.TRUE.,"getvar_in")

--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -11,10 +11,11 @@ CHARACTER(LEN=15) :: varnam
 
 CHARACTER(LEN=2048) :: file_in, file_out, cal, uni, his
 CHARACTER(LEN=2048) :: namelist_file
+CHARACTER(LEN=32)   :: z_name
 
 INTEGER :: ios, narg
 
-NAMELIST /vertical_extrapolation/ file_in, file_out, varnam
+NAMELIST /vertical_extrapolation/ file_in, file_out, varnam, z_name
 
 REAL*4,ALLOCATABLE,DIMENSION(:) :: z, y, x
 
@@ -28,6 +29,7 @@ REAL*4 :: miss
 file_in  = '__REQUIRED__'
 file_out = '__REQUIRED__'
 varnam   = '__REQUIRED__'
+z_name   = 'z'
 
 ! Determine namelist file (first command-line argument or default name)
 narg = COMMAND_ARGUMENT_COUNT()
@@ -78,7 +80,7 @@ status = NF90_OPEN(TRIM(file_in),0,fidA); call erreur(status,.TRUE.,"read")
 
 status = NF90_INQ_DIMID(fidA,"x",dimID_x); call erreur(status,.TRUE.,"inq_dimID_x")
 status = NF90_INQ_DIMID(fidA,"y",dimID_y); call erreur(status,.TRUE.,"inq_dimID_y")
-status = NF90_INQ_DIMID(fidA,"z",dimID_z); call erreur(status,.TRUE.,"inq_dimID_z")
+status = NF90_INQ_DIMID(fidA,TRIM(z_name),dimID_z); call erreur(status,.TRUE.,"inq_dimID_z")
 status = NF90_INQ_DIMID(fidA,"time",dimID_time); call erreur(status,.TRUE.,"inq_dimID_time")
 
 status = NF90_INQUIRE_DIMENSION(fidA,dimID_x,len=mx); call erreur(status,.TRUE.,"inq_dim_x")
@@ -93,7 +95,7 @@ ALLOCATE(  x(mx)  )
 ALLOCATE(  var_in(mx,my,mz)  )
 
 status = NF90_INQ_VARID(fidA,"time",time_ID); call erreur(status,.TRUE.,"inq_time_ID")
-status = NF90_INQ_VARID(fidA,"z",z_ID); call erreur(status,.TRUE.,"inq_z_ID")
+status = NF90_INQ_VARID(fidA,TRIM(z_name),z_ID); call erreur(status,.TRUE.,"inq_z_ID")
 status = NF90_INQ_VARID(fidA,"y",y_ID); call erreur(status,.TRUE.,"inq_y_ID")
 status = NF90_INQ_VARID(fidA,"x",x_ID); call erreur(status,.TRUE.,"inq_x_ID")
 status = NF90_INQ_VARID(fidA,TRIM(varnam),var_in_ID); call erreur(status,.TRUE.,"inq_var_ID")
@@ -131,11 +133,11 @@ status = NF90_CREATE(TRIM(file_out),NF90_NOCLOBBER,fidM); call erreur(status,.TR
 
 status = NF90_DEF_DIM(fidM,"x",mx,dimID_x); call erreur(status,.TRUE.,"def_dimID_x")
 status = NF90_DEF_DIM(fidM,"y",my,dimID_y); call erreur(status,.TRUE.,"def_dimID_y")
-status = NF90_DEF_DIM(fidM,"z",mz,dimID_z); call erreur(status,.TRUE.,"def_dimID_z")
+status = NF90_DEF_DIM(fidM,TRIM(z_name),mz,dimID_z); call erreur(status,.TRUE.,"def_dimID_z")
 status = NF90_DEF_DIM(fidM,"time",NF90_UNLIMITED,dimID_time); call erreur(status,.TRUE.,"def_dimID_time")
 
 status = NF90_DEF_VAR(fidM,"time",NF90_DOUBLE,(/dimID_time/),time_ID); call erreur(status,.TRUE.,"def_var_time_ID")
-status = NF90_DEF_VAR(fidM,"z",NF90_FLOAT,(/dimID_z/),z_ID); call erreur(status,.TRUE.,"def_var_z_ID")
+status = NF90_DEF_VAR(fidM,TRIM(z_name),NF90_FLOAT,(/dimID_z/),z_ID); call erreur(status,.TRUE.,"def_var_z_ID")
 status = NF90_DEF_VAR(fidM,"y",NF90_FLOAT,(/dimID_y/),y_ID); call erreur(status,.TRUE.,"def_var_y_ID")
 status = NF90_DEF_VAR(fidM,"x",NF90_FLOAT,(/dimID_x/),x_ID); call erreur(status,.TRUE.,"def_var_x_ID")
 status = NF90_DEF_VAR(fidM,TRIM(varnam),NF90_FLOAT,(/dimID_x,dimID_y,dimID_z,dimID_time/),var_out_ID); call erreur(status,.TRUE.,"def_var_var_ID")

--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -7,10 +7,10 @@ IMPLICIT NONE
 INTEGER :: fidA, status, dimID_x, dimID_y, dimID_z, dimID_time, mx, my, mz, mtime, time_ID, &
 &          z_ID, y_ID, x_ID, var_in_ID, var_out_ID, fidM, ki, kj, kz, kt
 
-CHARACTER(LEN=10) :: varnam
+CHARACTER(LEN=15) :: varnam
 
-CHARACTER(LEN=150) :: file_in, file_out, cal, uni, his
-CHARACTER(LEN=256) :: namelist_file
+CHARACTER(LEN=2048) :: file_in, file_out, cal, uni, his
+CHARACTER(LEN=2048) :: namelist_file
 
 INTEGER :: ios, narg
 

--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -216,21 +216,23 @@ end program modif
 
 
 
-SUBROUTINE erreur(iret, lstop, chaine)
-  ! pour les messages d'erreur
+SUBROUTINE erreur(iret, lstop, context)
+  ! Error reporting helper: prints NetCDF error details.
+  ! If lstop is true, terminates the program with a non-zero exit code.
   USE netcdf
-  INTEGER, INTENT(in)                     :: iret
-  LOGICAL, INTENT(in)                     :: lstop
-  CHARACTER(LEN=*), INTENT(in)            :: chaine
-  !
-  CHARACTER(LEN=80)                       :: message
-  !
+  INTEGER, INTENT(in)                  :: iret
+  LOGICAL, INTENT(in)                  :: lstop
+  CHARACTER(LEN=*), INTENT(in)         :: context
+  CHARACTER(LEN=256)                   :: message
+
   IF ( iret .NE. 0 ) THEN
-    WRITE(*,*) 'ROUTINE: ', TRIM(chaine)
-    WRITE(*,*) 'ERREUR: ', iret
-    message=NF90_STRERROR(iret)
-    WRITE(*,*) 'CA VEUT DIRE:',TRIM(message)
-    IF ( lstop ) STOP
-  ENDIF
-  !
+    WRITE(*,*) 'ROUTINE: ', TRIM(context)
+    WRITE(*,*) 'ERROR code: ', iret
+    message = NF90_STRERROR(iret)
+    WRITE(*,*) 'NETCDF message: ', TRIM(message)
+    IF ( lstop ) THEN
+      STOP 1
+    END IF
+  END IF
+
 END SUBROUTINE erreur

--- a/i7aof/cmip/cesm2_waccm.cfg
+++ b/i7aof/cmip/cesm2_waccm.cfg
@@ -28,6 +28,13 @@ vert_time_chunk = 1
 horiz_time_chunk = 120
 
 
+## Config options related to extrapolation of remapped CMIP datasets
+[extrap_cmip]
+
+# size of time chunks (months) to process per Fortran run
+time_chunk = 12
+
+
 ## Historical monthly mean data files
 [historical_files]
 

--- a/i7aof/cmip/cesm2_waccm.cfg
+++ b/i7aof/cmip/cesm2_waccm.cfg
@@ -32,7 +32,11 @@ horiz_time_chunk = 120
 [extrap_cmip]
 
 # size of time chunks (months) to process per Fortran run
-time_chunk = 12
+time_chunk = 24
+
+# number of parallel workers (processes) for time chunks; use 'auto' to leave
+# one core free for dispatch on the current machine
+num_workers = 32
 
 
 ## Historical monthly mean data files

--- a/i7aof/cmip/cesm2_waccm.cfg
+++ b/i7aof/cmip/cesm2_waccm.cfg
@@ -32,7 +32,7 @@ horiz_time_chunk = 120
 [extrap_cmip]
 
 # size of time chunks (months) to process per Fortran run
-time_chunk = 24
+time_chunk = 1
 
 # number of parallel workers (processes) for time chunks; use 'auto' to leave
 # one core free for dispatch on the current machine

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -78,6 +78,13 @@ vert_time_chunk = 1
 horiz_time_chunk = 120
 
 
+## Config options related to extrapolation of remapped CMIP datasets
+[extrap_cmip]
+
+# size of time chunks (months) to process per Fortran run
+time_chunk = 12
+
+
 ## config options related to the present-day topography dataset
 [topo]
 # the topography dataset

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -84,6 +84,10 @@ horiz_time_chunk = 120
 # size of time chunks (months) to process per Fortran run
 time_chunk = 12
 
+# number of parallel workers (processes) for time chunks; use 'auto' to leave
+# one core free for dispatch on the current machine
+num_workers = 1
+
 
 ## config options related to the present-day topography dataset
 [topo]

--- a/i7aof/extrap/__init__.py
+++ b/i7aof/extrap/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities for generating Fortran extrapolation namelists.
+
+This subpackage currently ships a Jinja2 template that can be rendered to
+produce a combined horizontal + vertical extrapolation namelist consumed by
+the Fortran executables.
+"""
+
+from importlib import resources as _resources
+
+__all__ = ['get_template_path', 'load_template_text']
+
+
+def get_template_path() -> str:
+    """Return the filesystem path to the bundled Jinja2 namelist template."""
+    template = _resources.files(__package__) / 'namelist_template.nml.j2'
+    with _resources.as_file(template) as p:
+        return str(p)
+
+
+def load_template_text() -> str:
+    """Return the contents of the bundled Jinja2 namelist template."""
+    template = _resources.files(__package__) / 'namelist_template.nml.j2'
+    return template.read_text(encoding='utf-8')

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -482,18 +482,16 @@ def _process_task(
             if config.has_option('extrap_cmip', 'num_workers')
             else '1'
         )
-    if isinstance(raw_workers, str):
-        rw = raw_workers.strip().lower()
-        if rw in ('auto', '0'):
-            cpu_cnt = os.cpu_count() or 1
-            num_workers = max(cpu_cnt - 1, 1)
-        else:
-            try:
-                num_workers = int(raw_workers)
-            except ValueError:
-                num_workers = 1
+
+    rw = raw_workers.strip().lower()
+    if rw in ('auto', '0'):
+        cpu_cnt = os.cpu_count() or 1
+        num_workers = max(cpu_cnt - 1, 1)
     else:
-        num_workers = int(raw_workers)
+        try:
+            num_workers = int(raw_workers)
+        except ValueError:
+            num_workers = 1
 
     with LoggingContext(__name__):
         logger = logging.getLogger(__name__)

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -1,0 +1,463 @@
+"""
+Extrapolate remapped CMIP ``ct``/``sa`` fields horizontally and vertically.
+
+Workflow
+========
+Consumes remapped monthly ``ct``/``sa`` files produced by the remap step:
+  workdir/remap/<model>/<scenario>/Omon/ct_sa/*ismip<res>.nc
+
+Produces per input file and per variable vertically extrapolated outputs:
+  workdir/extrap/<model>/<scenario>/Omon/ct_sa/*ismip<res>_extrap.nc
+with ``ct_sa`` in the filename replaced by the variable name (``ct`` or
+``sa``).
+
+Two external Fortran executables are invoked sequentially for each variable:
+  * i7aof_extrap_horizontal  (&horizontal_extrapolation namelist)
+  * i7aof_extrap_vertical    (&vertical_extrapolation namelist)
+
+A single combined namelist (containing both groups) is rendered from the
+Jinja2 template ``namelist_template.nml.j2`` via :func:`load_template_text`.
+
+Supporting data (auto-generated if missing)
+------------------------------------------
+If required inputs for IMBIE basin masks or topography are absent, the
+workflow attempts to build them on the fly inside ``workdir``:
+
+    * IMBIE basins: uses :func:`i7aof.imbie.masks.make_imbie_masks` to produce
+        ``imbie/basinNumbers_<res>.nc`` (downloading shapefiles as needed).
+    * Topography: constructs the configured dataset (e.g. BedMachine) via
+        :func:`i7aof.topo.get_topo`; if the remapped ISMIP file is missing it
+        runs ``download_and_preprocess_topo()`` (which may require a manually
+        downloaded source file for licensed data) followed by
+        ``remap_topo_to_ismip()``.
+
+If a required manual download (e.g. BedMachine original file) is not present
+an informative ``FileNotFoundError`` is raised.
+
+Execution is strictly serial for memory safety (no parallelism).
+
+Logging uses :class:`mpas_tools.logging.LoggingContext` so future redirecting
+to log files requires no code changes.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from jinja2 import BaseLoader, Environment
+from mpas_tools.config import MpasConfigParser
+from mpas_tools.logging import LoggingContext
+
+from i7aof.cmip import get_model_prefix
+from i7aof.extrap import load_template_text
+from i7aof.grid.ismip import get_res_string
+from i7aof.imbie.masks import make_imbie_masks
+from i7aof.topo import get_topo
+
+__all__ = ['extrap_cmip', 'main']
+
+
+@dataclass
+class FileTask:
+    """Per-variable extrapolation work for one remapped input file."""
+
+    in_path: str
+    out_path: str  # final vertical output
+    horizontal_tmp: str  # horizontal intermediate
+    namelist_path: str  # combined rendered namelist
+    variable: str  # e.g. 'ct' or 'sa'
+
+
+def extrap_cmip(
+    model: str,
+    scenario: str,
+    workdir: str | None = None,
+    user_config_filename: str | None = None,
+    variables: Sequence[str] = ('ct', 'sa'),
+    keep_intermediate: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """
+    Extrapolate remapped CMIP ``ct``/``sa`` fields horizontally and vertically.
+
+    Workflow
+    ========
+    Consumes remapped monthly ``ct``/``sa`` files produced by the remap step:
+    workdir/remap/<model>/<scenario>/Omon/ct_sa/*ismip<res>.nc
+
+    Produces per input file and per variable vertically extrapolated outputs:
+    workdir/extrap/<model>/<scenario>/Omon/ct_sa/*ismip<res>_extrap.nc
+    with ``ct_sa`` in the filename replaced by the variable name (``ct`` or
+    ``sa``).
+
+    Two external Fortran executables are invoked sequentially for each
+    variable:
+
+        * i7aof_extrap_horizontal  (&horizontal_extrapolation namelist)
+
+        * i7aof_extrap_vertical    (&vertical_extrapolation namelist)
+
+    A single combined namelist (containing both groups) is rendered from the
+    Jinja2 template ``namelist_template.nml.j2`` via
+    :func:`load_template_text`.
+
+    Supporting data (auto-generated if missing)
+    ------------------------------------------
+    If the IMBIE basin mask (``imbie/basinNumbers_<res>.nc``) or the ISMIP
+    remapped topography file is absent, they are generated on demand. IMBIE
+    shapefiles are downloaded automatically; topography may require a
+    manually obtained source file (e.g. BedMachine) before preprocessing.
+
+    Execution is strictly serial for memory safety (no parallelism).
+
+    Logging uses :class:`mpas_tools.logging.LoggingContext` so future
+    redirecting to log files requires no code changes.
+
+    Parameters
+    ----------
+    model : str
+        CMIP model name.
+    scenario : str
+        Scenario key (e.g., ``historical`` or ``ssp585``).
+    workdir : str, optional
+        Base working directory; if omitted, uses config ``[workdir] base_dir``.
+    user_config_filename : str, optional
+        Optional user config overriding defaults.
+    variables : sequence of str, optional
+        Variable names to extrapolate (default: ``ct`` and ``sa``).
+    keep_intermediate : bool, optional
+        Keep horizontal temp and namelist files if True.
+    dry_run : bool, optional
+        If True, list planned actions only.
+    """
+
+    (
+        config,
+        workdir,
+        remap_dir,
+        out_dir,
+        ismip_res_str,
+        _model_prefix,
+    ) = _prepare_paths_and_config(
+        model=model,
+        scenario=scenario,
+        workdir=workdir,
+        user_config_filename=user_config_filename,
+    )
+
+    in_files = _collect_remap_outputs(remap_dir, ismip_res_str)
+    if not in_files:
+        raise FileNotFoundError(
+            'No remapped ct/sa files found. Run: ismip7-antarctic-remap-cmip'
+        )
+
+    basin_file = _ensure_imbie_masks(config, workdir)
+    topo_file = _ensure_topography(config, workdir)
+
+    for in_file in in_files:
+        base = os.path.basename(in_file)
+        for var in variables:
+            out_base = base.replace('ct_sa', var)
+            out_path = os.path.join(out_dir, out_base)
+            horizontal_tmp = out_path.replace('.nc', '_horizontal_tmp.nc')
+            namelist_path = out_path.replace('.nc', f'_{var}.nml')
+            task = FileTask(
+                in_path=in_file,
+                out_path=out_path,
+                horizontal_tmp=horizontal_tmp,
+                namelist_path=namelist_path,
+                variable=var,
+            )
+            _process_task(
+                task,
+                basin_file=basin_file,
+                topo_file=topo_file,
+                keep_intermediate=keep_intermediate,
+                dry_run=dry_run,
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            'Extrapolate remapped CMIP ct/sa (horizontal + vertical) using '
+            'Fortran executables.'
+        )
+    )
+    parser.add_argument(
+        '-m',
+        '--model',
+        dest='model',
+        required=True,
+        help='CMIP model name (required).',
+    )
+    parser.add_argument(
+        '-s',
+        '--scenario',
+        dest='scenario',
+        required=True,
+        help='Scenario key (historical, ssp585, ...: required).',
+    )
+    parser.add_argument(
+        '-w',
+        '--workdir',
+        dest='workdir',
+        required=False,
+        help='Base working directory (optional; else from config).',
+    )
+    parser.add_argument(
+        '-c',
+        '--config',
+        dest='config',
+        default=None,
+        help='Path to user config file (optional).',
+    )
+    parser.add_argument(
+        '-V',
+        '--variables',
+        nargs='+',
+        default=['ct', 'sa'],
+        help='Variables to extrapolate (default: ct sa).',
+    )
+    parser.add_argument(
+        '--keep-intermediate',
+        action='store_true',
+        help='Keep horizontal intermediate NetCDF and namelist files.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Show planned actions without running executables.',
+    )
+    args = parser.parse_args()
+
+    extrap_cmip(
+        model=args.model,
+        scenario=args.scenario,
+        workdir=args.workdir,
+        user_config_filename=args.config,
+        variables=args.variables,
+        keep_intermediate=args.keep_intermediate,
+        dry_run=args.dry_run,
+    )
+
+
+def _prepare_paths_and_config(
+    model: str,
+    scenario: str,
+    workdir: str | None,
+    user_config_filename: str | None,
+):
+    model_prefix = get_model_prefix(model)
+    config = MpasConfigParser()
+    config.add_from_package('i7aof', 'default.cfg')
+    config.add_from_package('i7aof.cmip', f'{model_prefix}.cfg')
+    if user_config_filename is not None:
+        config.add_user_config(user_config_filename)
+    if workdir is None:
+        if config.has_option('workdir', 'base_dir'):
+            workdir = config.get('workdir', 'base_dir')
+        else:  # pragma: no cover
+            raise ValueError(
+                'Missing configuration option: [workdir] base_dir.'
+            )
+    # At this point workdir must be a concrete string for path joins
+    assert workdir is not None, (
+        'Internal error: workdir should be resolved to a string'
+    )
+    remap_dir = os.path.join(
+        workdir, 'remap', model, scenario, 'Omon', 'ct_sa'
+    )
+    out_dir = os.path.join(workdir, 'extrap', model, scenario, 'Omon', 'ct_sa')
+    os.makedirs(out_dir, exist_ok=True)
+    ismip_res_str = get_res_string(config)
+    return config, workdir, remap_dir, out_dir, ismip_res_str, model_prefix
+
+
+def _collect_remap_outputs(remap_dir: str, ismip_res_str: str) -> List[str]:
+    if not os.path.isdir(remap_dir):
+        return []
+    result: List[str] = []
+    for name in sorted(os.listdir(remap_dir)):
+        if f'ismip{ismip_res_str}' in name and 'ct_sa' in name:
+            result.append(os.path.join(remap_dir, name))
+    return result
+
+
+def _ensure_imbie_masks(config, workdir: str) -> str:
+    """Ensure IMBIE basin mask NetCDF exists; build it if missing.
+
+    Returns
+    -------
+    str
+        Path to basin numbers NetCDF file.
+    """
+    # The output naming in make_imbie_masks is basinNumbers_<res>.nc
+    from i7aof.grid.ismip import get_horiz_res_string
+
+    res = get_horiz_res_string(config)
+    basin_file = os.path.join(workdir, 'imbie', f'basinNumbers_{res}.nc')
+    if not os.path.exists(basin_file):
+        cwd = os.getcwd()
+        try:
+            os.makedirs(os.path.join(workdir, 'imbie'), exist_ok=True)
+            os.chdir(workdir)
+            make_imbie_masks(config)
+        finally:
+            os.chdir(cwd)
+        if not os.path.exists(basin_file):  # safety check
+            raise FileNotFoundError(
+                f'Failed to generate IMBIE basin file: {basin_file}'
+            )
+    return basin_file
+
+
+def _ensure_topography(config, workdir: str) -> str:
+    """Ensure topography file on ISMIP grid exists; build it if missing.
+
+    Returns
+    -------
+    str
+        Path to the ISMIP-grid topography NetCDF file.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    cwd = os.getcwd()
+    try:
+        os.makedirs(os.path.join(workdir, 'topo'), exist_ok=True)
+        os.chdir(workdir)
+        topo_obj = get_topo(config, logger)
+        topo_path = topo_obj.get_topo_on_ismip_path()
+        if not os.path.exists(topo_path):
+            # Need intermediate preprocessed file first
+            try:
+                topo_obj.download_and_preprocess_topo()
+            except FileNotFoundError as e:
+                # Provide actionable message then re-raise
+                raise FileNotFoundError(
+                    f'Topography prerequisite missing: {e}. '
+                    'Please fetch required source data (see docs).'
+                ) from e
+            topo_obj.remap_topo_to_ismip()
+        if not os.path.exists(topo_path):
+            raise FileNotFoundError(
+                f'Failed to build topography file: {topo_path}'
+            )
+    finally:
+        os.chdir(cwd)
+    return os.path.join(workdir, topo_path)
+
+
+def _render_namelist(
+    file_in: str,
+    horizontal_out: str,
+    vertical_out: str,
+    basin_file: str,
+    topo_file: str,
+    variable: str,
+) -> str:
+    template_txt = load_template_text()
+    env = Environment(
+        loader=BaseLoader(),
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.from_string(template_txt)
+    return template.render(
+        file_in=file_in,
+        horizontal_out=horizontal_out,
+        vertical_out=vertical_out,
+        file_basin=basin_file,
+        file_topo=topo_file,
+        var_name=variable,
+    )
+
+
+def _process_task(
+    task: FileTask,
+    basin_file: str,
+    topo_file: str,
+    keep_intermediate: bool,
+    dry_run: bool,
+) -> None:
+    if os.path.exists(task.out_path):
+        print(f'Extrapolated file exists, skipping: {task.out_path}')
+        return
+    os.makedirs(os.path.dirname(task.out_path), exist_ok=True)
+
+    namelist_contents = _render_namelist(
+        file_in=task.in_path,
+        horizontal_out=task.horizontal_tmp,
+        vertical_out=task.out_path,
+        basin_file=basin_file,
+        topo_file=topo_file,
+        variable=task.variable,
+    )
+    with open(task.namelist_path, 'w', encoding='utf-8') as f:
+        f.write(namelist_contents)
+
+    import logging
+
+    with LoggingContext(__name__):
+        logger = logging.getLogger(__name__)
+        logger.info(
+            f'Starting extrapolation: {task.in_path} '
+            f'(variable={task.variable})'
+        )
+        logger.info(f'  Namelist: {task.namelist_path}')
+        logger.info(f'  Horizontal tmp: {task.horizontal_tmp}')
+        logger.info(f'  Final output: {task.out_path}')
+
+        horiz_exec = 'i7aof_extrap_horizontal'
+        vert_exec = 'i7aof_extrap_vertical'
+        for exe in (horiz_exec, vert_exec):
+            if shutil.which(exe) is None:
+                raise FileNotFoundError(
+                    f"Required executable '{exe}' not found on PATH."
+                )
+
+        if dry_run:
+            logger.info('Dry-run mode: skipping Fortran execution.')
+        else:
+            _run_exe(horiz_exec, task.namelist_path, logger, 'horizontal')
+            _run_exe(vert_exec, task.namelist_path, logger, 'vertical')
+
+        if not keep_intermediate:
+            _cleanup_intermediate(task, logger)
+        else:
+            logger.info('Keeping intermediate horizontal file and namelist.')
+
+
+def _run_exe(exe: str, namelist: str, logger, phase: str) -> None:
+    # Fortran executables expect the namelist file path as argv(1)
+    logger.info(f'Running {phase} extrapolation executable: {exe} {namelist}')
+    try:
+        proc = subprocess.run(
+            [exe, namelist],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=True,
+            text=True,
+        )
+        logger.info(f'{exe} output:\n{proc.stdout.strip()}')
+    except subprocess.CalledProcessError as e:  # pragma: no cover
+        logger.error(
+            f'Execution failed for {exe} (phase={phase}) rc={e.returncode}'
+        )
+        logger.error(f'Combined stdout/stderr:\n{e.stdout}')
+        raise
+
+
+def _cleanup_intermediate(task: FileTask, logger) -> None:
+    for path in (task.horizontal_tmp, task.namelist_path):
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+                logger.info(f'Removed intermediate: {path}')
+        except OSError as e:  # pragma: no cover
+            logger.warning(f'Failed to remove intermediate {path}: {e}')

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -41,20 +41,28 @@ to log files requires no code changes.
 """
 
 import argparse
+import logging
 import os
 import shutil
 import subprocess
 from dataclasses import dataclass
 from typing import List, Sequence
 
+import xarray as xr
 from jinja2 import BaseLoader, Environment
 from mpas_tools.config import MpasConfigParser
 from mpas_tools.logging import LoggingContext
 
 from i7aof.cmip import get_model_prefix
 from i7aof.extrap import load_template_text
-from i7aof.grid.ismip import get_res_string
+from i7aof.grid.ismip import (
+    get_horiz_res_string,
+    get_ismip_grid_filename,
+    get_res_string,
+    write_ismip_grid,
+)
 from i7aof.imbie.masks import make_imbie_masks
+from i7aof.io import write_netcdf
 from i7aof.topo import get_topo
 
 __all__ = ['extrap_cmip', 'main']
@@ -69,6 +77,7 @@ class FileTask:
     horizontal_tmp: str  # horizontal intermediate
     namelist_path: str  # combined rendered namelist
     variable: str  # e.g. 'ct' or 'sa'
+    tmp_dir: str  # directory for all intermediates for this file
 
 
 def extrap_cmip(
@@ -155,6 +164,7 @@ def extrap_cmip(
         )
 
     basin_file = _ensure_imbie_masks(config, workdir)
+    grid_file = _ensure_ismip_grid(config, workdir)
     topo_file = _ensure_topography(config, workdir)
 
     for in_file in in_files:
@@ -162,18 +172,22 @@ def extrap_cmip(
         for var in variables:
             out_base = base.replace('ct_sa', var)
             out_path = os.path.join(out_dir, out_base)
-            horizontal_tmp = out_path.replace('.nc', '_horizontal_tmp.nc')
-            namelist_path = out_path.replace('.nc', f'_{var}.nml')
+            stem = os.path.splitext(os.path.basename(out_path))[0]
+            tmp_dir = os.path.join(os.path.dirname(out_path), f'{stem}_tmp')
+            horizontal_tmp = os.path.join(tmp_dir, 'horizontal_tmp.nc')
+            namelist_path = os.path.join(tmp_dir, f'{var}.nml')
             task = FileTask(
                 in_path=in_file,
                 out_path=out_path,
                 horizontal_tmp=horizontal_tmp,
                 namelist_path=namelist_path,
                 variable=var,
+                tmp_dir=tmp_dir,
             )
             _process_task(
                 task,
                 basin_file=basin_file,
+                grid_file=grid_file,
                 topo_file=topo_file,
                 keep_intermediate=keep_intermediate,
                 dry_run=dry_run,
@@ -296,7 +310,6 @@ def _ensure_imbie_masks(config, workdir: str) -> str:
         Path to basin numbers NetCDF file.
     """
     # The output naming in make_imbie_masks is basinNumbers_<res>.nc
-    from i7aof.grid.ismip import get_horiz_res_string
 
     res = get_horiz_res_string(config)
     basin_file = os.path.join(workdir, 'imbie', f'basinNumbers_{res}.nc')
@@ -323,8 +336,6 @@ def _ensure_topography(config, workdir: str) -> str:
     str
         Path to the ISMIP-grid topography NetCDF file.
     """
-    import logging
-
     logger = logging.getLogger(__name__)
     cwd = os.getcwd()
     try:
@@ -350,6 +361,25 @@ def _ensure_topography(config, workdir: str) -> str:
     finally:
         os.chdir(cwd)
     return os.path.join(workdir, topo_path)
+
+
+def _ensure_ismip_grid(config, workdir: str) -> str:
+    """Ensure ISMIP grid exists under workdir and return absolute path."""
+    grid_rel = get_ismip_grid_filename(config)
+    grid_abs = os.path.join(workdir, grid_rel)
+    if not os.path.exists(grid_abs):
+        cwd = os.getcwd()
+        try:
+            os.makedirs(os.path.dirname(grid_abs), exist_ok=True)
+            os.chdir(workdir)
+            write_ismip_grid(config)
+        finally:
+            os.chdir(cwd)
+        if not os.path.exists(grid_abs):
+            raise FileNotFoundError(
+                f'Failed to generate ISMIP grid file: {grid_abs}'
+            )
+    return grid_abs
 
 
 def _render_namelist(
@@ -382,6 +412,7 @@ def _render_namelist(
 def _process_task(
     task: FileTask,
     basin_file: str,
+    grid_file: str,
     topo_file: str,
     keep_intermediate: bool,
     dry_run: bool,
@@ -390,19 +421,25 @@ def _process_task(
         print(f'Extrapolated file exists, skipping: {task.out_path}')
         return
     os.makedirs(os.path.dirname(task.out_path), exist_ok=True)
+    os.makedirs(task.tmp_dir, exist_ok=True)
+
+    # Prepare input with x/y coordinates if missing
+    prepared_input = os.path.join(task.tmp_dir, 'input_prepared.nc')
+    _prepare_input_with_coords(task.in_path, grid_file, prepared_input)
+
+    # Temporary vertical output; we'll copy grid variables after Fortran runs
+    vertical_tmp = os.path.join(task.tmp_dir, 'vertical_tmp.nc')
 
     namelist_contents = _render_namelist(
-        file_in=task.in_path,
+        file_in=prepared_input,
         horizontal_out=task.horizontal_tmp,
-        vertical_out=task.out_path,
+        vertical_out=vertical_tmp,
         basin_file=basin_file,
         topo_file=topo_file,
         variable=task.variable,
     )
     with open(task.namelist_path, 'w', encoding='utf-8') as f:
         f.write(namelist_contents)
-
-    import logging
 
     with LoggingContext(__name__):
         logger = logging.getLogger(__name__)
@@ -427,6 +464,14 @@ def _process_task(
         else:
             _run_exe(horiz_exec, task.namelist_path, logger, 'horizontal')
             _run_exe(vert_exec, task.namelist_path, logger, 'vertical')
+
+            # Finalize: add grid lat/lon/crs to final output
+            _finalize_output_with_grid(
+                vertical_tmp,
+                grid_file,
+                task.out_path,
+                logger,
+            )
 
         if not keep_intermediate:
             _cleanup_intermediate(task, logger)
@@ -455,10 +500,98 @@ def _run_exe(exe: str, namelist: str, logger, phase: str) -> None:
 
 
 def _cleanup_intermediate(task: FileTask, logger) -> None:
-    for path in (task.horizontal_tmp, task.namelist_path):
+    # Remove the entire temp directory safely
+    tmp_dir = task.tmp_dir
+    out_parent = os.path.dirname(task.out_path)
+    safe_parent = os.path.dirname(tmp_dir) == out_parent
+    safe_suffix = os.path.basename(tmp_dir).endswith('_tmp')
+    if os.path.isdir(tmp_dir) and safe_parent and safe_suffix:
         try:
-            if os.path.exists(path):
-                os.remove(path)
-                logger.info(f'Removed intermediate: {path}')
+            shutil.rmtree(tmp_dir)
+            logger.info(f'Removed temporary directory: {tmp_dir}')
         except OSError as e:  # pragma: no cover
-            logger.warning(f'Failed to remove intermediate {path}: {e}')
+            logger.warning(
+                f'Failed to remove temporary directory {tmp_dir}: {e}'
+            )
+
+
+def _prepare_input_with_coords(
+    in_path: str,
+    grid_path: str,
+    out_prepared_path: str,
+) -> None:
+    """Ensure input has x/y coordinates; add from ISMIP grid if missing.
+
+    Always writes a prepared copy to out_prepared_path.
+    """
+    ds_in = xr.open_dataset(in_path, chunks={'time': 1})
+    ds_grid = xr.open_dataset(grid_path)
+
+    to_add = {}
+    # Ensure dims exist and match sizes
+    for dim in ('x', 'y'):
+        if dim not in ds_in.dims:
+            raise KeyError(
+                f"Input file {in_path} missing required dimension '{dim}'."
+            )
+        if dim in ds_in.variables:
+            continue
+        # Use grid coordinates; basic size check
+        if ds_in.sizes[dim] != ds_grid.sizes[dim]:
+            raise ValueError(
+                f"Dim size mismatch for '{dim}': input={ds_in.sizes[dim]} "
+                f'grid={ds_grid.sizes[dim]}'
+            )
+        to_add[dim] = ds_grid[dim]
+
+    if to_add:
+        ds_in = ds_in.assign(to_add)
+
+    write_netcdf(ds_in, out_prepared_path, progress_bar=True)
+
+
+def _finalize_output_with_grid(
+    tmp_out_path: str,
+    grid_path: str,
+    final_out_path: str,
+    logger,
+) -> None:
+    """Copy/overwrite grid variables and coords from ISMIP grid into output.
+
+    We overwrite x, y, x_bnds, y_bnds, lat, lon, lat_bnds, lon_bnds, crs
+    using definitions from the grid file, preserving their attributes.
+    """
+    ds_out = xr.open_dataset(tmp_out_path, chunks={'time': 1})
+    ds_grid = xr.open_dataset(grid_path)
+
+    # Variables/coords to enforce from grid
+    coord_names = ['x', 'y']
+    var_names = [
+        'x_bnds',
+        'y_bnds',
+        'lat',
+        'lon',
+        'lat_bnds',
+        'lon_bnds',
+        'crs',
+    ]
+
+    # Drop any existing versions in output so we fully overwrite
+    drop_list = [v for v in (coord_names + var_names) if v in ds_out.variables]
+    if drop_list:
+        ds_out = ds_out.drop_vars(drop_list, errors='ignore')
+
+    to_add_coords = {v: ds_grid[v] for v in coord_names if v in ds_grid}
+    to_add_vars = {v: ds_grid[v] for v in var_names if v in ds_grid}
+
+    if to_add_coords:
+        names = ', '.join(sorted(to_add_coords.keys()))
+        logger.info(f'Overwriting grid coordinates in output: {names}')
+        ds_out = ds_out.assign_coords(to_add_coords)
+
+    if to_add_vars:
+        names = ', '.join(sorted(to_add_vars.keys()))
+        logger.info(f'Overwriting grid variables in output: {names}')
+        ds_out = ds_out.assign(to_add_vars)
+
+    write_netcdf(ds_out, final_out_path, progress_bar=True)

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -4,51 +4,68 @@ Extrapolate remapped CMIP ``ct``/``sa`` fields horizontally and vertically.
 Workflow
 ========
 Consumes remapped monthly ``ct``/``sa`` files produced by the remap step:
-  workdir/remap/<model>/<scenario>/Omon/ct_sa/*ismip<res>.nc
+
+    workdir/remap/<model>/<scenario>/Omon/ct_sa/*ismip<res>.nc
 
 Produces per input file and per variable vertically extrapolated outputs:
-  workdir/extrap/<model>/<scenario>/Omon/ct_sa/*ismip<res>_extrap.nc
+
+    workdir/extrap/<model>/<scenario>/Omon/ct_sa/*ismip<res>_extrap.nc
+
 with ``ct_sa`` in the filename replaced by the variable name (``ct`` or
 ``sa``).
 
 Two external Fortran executables are invoked sequentially for each variable:
-  * i7aof_extrap_horizontal  (&horizontal_extrapolation namelist)
-  * i7aof_extrap_vertical    (&vertical_extrapolation namelist)
+
+    * i7aof_extrap_horizontal  (&horizontal_extrapolation namelist)
+
+    * i7aof_extrap_vertical    (&vertical_extrapolation namelist)
 
 A single combined namelist (containing both groups) is rendered from the
 Jinja2 template ``namelist_template.nml.j2`` via :func:`load_template_text`.
+
+Parallel, chunked execution
+---------------------------
+Time is processed in chunks to limit memory and file sizes. Chunks run
+serially or in parallel (process-based) depending on configuration. Each
+chunk writes a per-chunk input, runs the Fortran executables, and records
+stdout/stderr and any Python traceback in a chunk log under
+``<out>_tmp/logs``. Abrupt worker failures are detected and reported with
+the set of completed vs. pending chunks for quick triage.
 
 Supporting data (auto-generated if missing)
 ------------------------------------------
 If required inputs for IMBIE basin masks or topography are absent, the
 workflow attempts to build them on the fly inside ``workdir``:
 
-    * IMBIE basins: uses :func:`i7aof.imbie.masks.make_imbie_masks` to produce
-        ``imbie/basinNumbers_<res>.nc`` (downloading shapefiles as needed).
-    * Topography: constructs the configured dataset (e.g. BedMachine) via
-        :func:`i7aof.topo.get_topo`; if the remapped ISMIP file is missing it
-        runs ``download_and_preprocess_topo()`` (which may require a manually
-        downloaded source file for licensed data) followed by
-        ``remap_topo_to_ismip()``.
+    * IMBIE basins: uses :func:`i7aof.imbie.masks.make_imbie_masks` to
+      produce ``imbie/basinNumbers_<res>.nc`` (downloading shapefiles as
+      needed).
 
-If a required manual download (e.g. BedMachine original file) is not present
+    * Topography: constructs the configured dataset (e.g. BedMachine)
+        via :func:`i7aof.topo.get_topo`; if the remapped ISMIP file is
+        missing it runs ``download_and_preprocess_topo()`` (which may
+        require a manually downloaded source file for licensed data)
+        followed by``remap_topo_to_ismip()``.
+
+If a required manual download (e.g., BedMachine source) is not present
 an informative ``FileNotFoundError`` is raised.
-
-Execution is strictly serial for memory safety (no parallelism).
-
-Logging uses :class:`mpas_tools.logging.LoggingContext` so future redirecting
-to log files requires no code changes.
 """
 
 import argparse
+import faulthandler
 import logging
+import multiprocessing as mp
 import os
 import shutil
 import subprocess
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
-from typing import List, Sequence
+from typing import List, Sequence, Tuple
 
 import xarray as xr
+from dask import config as dask_config
 from jinja2 import BaseLoader, Environment
 from mpas_tools.config import MpasConfigParser
 from mpas_tools.logging import LoggingContext
@@ -67,6 +84,10 @@ from i7aof.topo import get_topo
 
 __all__ = ['extrap_cmip', 'main']
 
+# Relax HDF5 file locking on parallel filesystems to reduce I/O errors when
+# writing from worker processes (safe on GPFS/Lustre; ignored otherwise).
+os.environ.setdefault('HDF5_USE_FILE_LOCKING', 'FALSE')
+
 
 @dataclass
 class FileTask:
@@ -79,6 +100,22 @@ class FileTask:
     tmp_dir: str  # directory for all intermediates for this file
 
 
+@dataclass
+class ChunkFailed(Exception):
+    """Represents a failure in a specific time chunk, with context."""
+
+    i0: int
+    i1: int
+    log_path: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - formatting helper
+        return (
+            f'Chunk {self.i0}:{self.i1} failed: {self.message} '
+            f'(see log: {self.log_path})'
+        )
+
+
 def extrap_cmip(
     model: str,
     scenario: str,
@@ -86,42 +123,39 @@ def extrap_cmip(
     user_config_filename: str | None = None,
     variables: Sequence[str] = ('ct', 'sa'),
     keep_intermediate: bool = False,
+    num_workers: int | str | None = None,
 ) -> None:
     """
-    Extrapolate remapped CMIP ``ct``/``sa`` fields horizontally and vertically.
+    Extrapolate remapped CMIP ``ct``/``sa`` fields horizontally and
+    vertically in time chunks, optionally in parallel.
 
-    Workflow
-    ========
-    Consumes remapped monthly ``ct``/``sa`` files produced by the remap step:
-    workdir/remap/<model>/<scenario>/Omon/ct_sa/*ismip<res>.nc
+    Overview
+    --------
+    For each input file under
+    ``workdir/remap/<model>/<scenario>/Omon/ct_sa/*ismip<res>.nc``, this
+    function:
 
-    Produces per input file and per variable vertically extrapolated outputs:
-    workdir/extrap/<model>/<scenario>/Omon/ct_sa/*ismip<res>_extrap.nc
-    with ``ct_sa`` in the filename replaced by the variable name (``ct`` or
-    ``sa``).
+      1. Splits the time dimension into chunks (``extrap_cmip.time_chunk``).
 
-    Two external Fortran executables are invoked sequentially for each
-    variable:
+      2. For each chunk, writes a per-chunk input on the ISMIP grid with
+         coordinates ensured and only required variables kept.
 
-        * i7aof_extrap_horizontal  (&horizontal_extrapolation namelist)
+      3. Invokes the Fortran executables sequentially
+         (horizontal then vertical) using a rendered namelist.
 
-        * i7aof_extrap_vertical    (&vertical_extrapolation namelist)
+      4. Captures Fortran stdout/stderr in a per-chunk log and appends a
+         Python traceback on any error for that chunk.
 
-    A single combined namelist (containing both groups) is rendered from the
-    Jinja2 template ``namelist_template.nml.j2`` via
-    :func:`load_template_text`.
+      5. Concatenates vertical outputs along time and injects grid
+         coordinates/variables into the final output file.
 
-    Supporting data (auto-generated if missing)
-    ------------------------------------------
-    If the IMBIE basin mask (``imbie/basinNumbers_<res>.nc``) or the ISMIP
-    remapped topography file is absent, they are generated on demand. IMBIE
-    shapefiles are downloaded automatically; topography may require a
-    manually obtained source file (e.g. BedMachine) before preprocessing.
-
-    Execution is strictly serial for memory safety (no parallelism).
-
-    Logging uses :class:`mpas_tools.logging.LoggingContext` so future
-    redirecting to log files requires no code changes.
+    Execution is process-parallel with a configurable number of workers.
+    When a worker fails, the failing chunk indices and log path are
+    reported; if the pool crashes, the set of completed vs. pending chunks
+    is logged to direct debugging. Dask is required and used with a
+    synchronous scheduler during per-chunk input writes to avoid
+    multi-threaded HDF5 access. BLAS/OMP threads are pinned to 1 for each
+    worker. HDF5 file locking is relaxed by default.
 
     Parameters
     ----------
@@ -130,13 +164,19 @@ def extrap_cmip(
     scenario : str
         Scenario key (e.g., ``historical`` or ``ssp585``).
     workdir : str, optional
-        Base working directory; if omitted, uses config ``[workdir] base_dir``.
+        Base working directory; if omitted, uses config
+        ``[workdir] base_dir``.
     user_config_filename : str, optional
         Optional user config overriding defaults.
     variables : sequence of str, optional
         Variable names to extrapolate (default: ``ct`` and ``sa``).
     keep_intermediate : bool, optional
-        Keep horizontal temp and namelist files if True.
+        Keep horizontal temps and namelists if True; otherwise delete the
+        ``*_tmp`` directory after finalization.
+    num_workers : int | str | None, optional
+        Number of parallel workers. Pass an integer, or ``"auto"``/``0``
+        to use ``cpu_count - 1``. If omitted, read from config
+        ``[extrap_cmip] num_workers``.
     """
 
     (
@@ -185,6 +225,7 @@ def extrap_cmip(
                 grid_file=grid_file,
                 topo_file=topo_file,
                 keep_intermediate=keep_intermediate,
+                num_workers_override=num_workers,
             )
 
 
@@ -235,6 +276,15 @@ def main() -> None:
         action='store_true',
         help='Keep horizontal intermediate NetCDF and namelist files.',
     )
+    parser.add_argument(
+        '--num_workers',
+        dest='num_workers',
+        default=None,
+        help=(
+            'Number of parallel workers (processes). Use "auto" or 0 to '
+            'leave one core free. Default: from config (extrap_cmip).'
+        ),
+    )
     args = parser.parse_args()
 
     extrap_cmip(
@@ -244,6 +294,7 @@ def main() -> None:
         user_config_filename=args.config,
         variables=args.variables,
         keep_intermediate=args.keep_intermediate,
+        num_workers=args.num_workers,
     )
 
 
@@ -409,6 +460,7 @@ def _process_task(
     grid_file: str,
     topo_file: str,
     keep_intermediate: bool,
+    num_workers_override: int | str | None = None,
 ) -> None:
     if os.path.exists(task.out_path):
         print(f'Extrapolated file exists, skipping: {task.out_path}')
@@ -417,12 +469,31 @@ def _process_task(
     os.makedirs(task.tmp_dir, exist_ok=True)
 
     # We'll preprocess per time chunk to keep memory and file sizes in check
-    # Determine chunking in time (default 120 months)
-    try:
-        time_chunk = config.getint('extrap_cmip', 'time_chunk')
-    except Exception:
-        # Fallback safety: default to 120 if section/option is missing
-        time_chunk = 120
+    # Determine chunking in time
+    time_chunk = config.getint('extrap_cmip', 'time_chunk')
+
+    # Number of parallel workers and per-chunk logging
+    # Accept integer, or the string 'auto'/'0' to mean (cpu_count - 1)
+    if num_workers_override is not None:
+        raw_workers = str(num_workers_override)
+    else:
+        raw_workers = (
+            config.get('extrap_cmip', 'num_workers')
+            if config.has_option('extrap_cmip', 'num_workers')
+            else '1'
+        )
+    if isinstance(raw_workers, str):
+        rw = raw_workers.strip().lower()
+        if rw in ('auto', '0'):
+            cpu_cnt = os.cpu_count() or 1
+            num_workers = max(cpu_cnt - 1, 1)
+        else:
+            try:
+                num_workers = int(raw_workers)
+            except ValueError:
+                num_workers = 1
+    else:
+        num_workers = int(raw_workers)
 
     with LoggingContext(__name__):
         logger = logging.getLogger(__name__)
@@ -441,91 +512,48 @@ def _process_task(
                 )
 
         # Open source input lazily to compute chunk indices
-        ds_meta = xr.open_dataset(task.in_path, decode_times=False)
-        if 'time' not in ds_meta.dims:
-            # No time dimension; process as a single synthetic chunk
-            time_indices = [(0, 1)]
-        else:
-            n_time = ds_meta.sizes['time']
-            time_indices = [
-                (i0, min(i0 + time_chunk, n_time))
-                for i0 in range(0, n_time, time_chunk)
-            ]
+        with xr.open_dataset(task.in_path, decode_times=False) as ds_meta:
+            has_time = 'time' in ds_meta.dims
+            if not has_time:
+                # No time dimension; process as a single synthetic chunk
+                time_indices = [(0, 1)]
+            else:
+                n_time = ds_meta.sizes['time']
+                time_indices = [
+                    (i0, min(i0 + time_chunk, n_time))
+                    for i0 in range(0, n_time, time_chunk)
+                ]
 
-        vertical_chunks: List[str] = []
+        # Execute all chunks (serial or parallel)
+        vertical_chunks = _execute_time_chunks(
+            task=task,
+            grid_file=grid_file,
+            basin_file=basin_file,
+            topo_file=topo_file,
+            time_indices=time_indices,
+            horiz_exec=horiz_exec,
+            vert_exec=vert_exec,
+            num_workers=num_workers,
+            has_time=has_time,
+            logger=logger,
+        )
 
-        for i0, i1 in time_indices:
-            # Prepare per-chunk input file
-            if i1 == 0:
-                # Empty time dimension; nothing to do
-                continue
-            input_chunk = os.path.join(task.tmp_dir, f'input_{i0}_{i1}.nc')
-            if not os.path.exists(input_chunk):
-                # Preprocess only this time slice with grid coordinates
-                _prepare_input_with_coords(
-                    task.in_path,
-                    grid_file,
-                    input_chunk,
-                    task.variable,
-                    time_slice=(i0, i1) if 'time' in ds_meta.dims else None,
-                )
-
-            horizontal_tmp = os.path.join(
-                task.tmp_dir, f'horizontal_{i0}_{i1}.nc'
-            )
-            vertical_tmp = os.path.join(task.tmp_dir, f'vertical_{i0}_{i1}.nc')
-
-            # Render a per-chunk namelist
-            namelist_contents = _render_namelist(
-                file_in=input_chunk,
-                horizontal_out=horizontal_tmp,
-                vertical_out=vertical_tmp,
-                basin_file=basin_file,
-                topo_file=topo_file,
-                variable=task.variable,
-            )
-            namelist_path = os.path.join(
-                task.tmp_dir, f'{task.variable}_{i0}_{i1}.nml'
-            )
-            with open(namelist_path, 'w', encoding='utf-8') as f:
-                f.write(namelist_contents)
-
-            logger.info(
-                (
-                    f'  Chunk {i0}:{i1} -> horiz '
-                    f'{os.path.basename(horizontal_tmp)}, '
-                    f'vert {os.path.basename(vertical_tmp)}'
-                )
-            )
-
-            # Run horizontal and vertical phases if outputs are missing
-            if not os.path.exists(horizontal_tmp):
-                _run_exe(horiz_exec, namelist_path, logger, 'horizontal')
-            if not os.path.exists(vertical_tmp):
-                _run_exe(vert_exec, namelist_path, logger, 'vertical')
-
-            if not os.path.exists(vertical_tmp):
-                raise FileNotFoundError(
-                    f'Expected vertical output missing: {vertical_tmp}'
-                )
-            vertical_chunks.append(vertical_tmp)
-
-        if not vertical_chunks:
-            raise RuntimeError(
-                'No vertical output chunks were produced; aborting.'
-            )
-
-        # Concatenate chunks along time in-memory (lazy) and finalize once
+        # Sort by start index and concatenate along time
+        vertical_chunks.sort(key=lambda t: t[0])
         if len(vertical_chunks) == 1:
             ds_final_in = xr.open_dataset(
-                vertical_chunks[0], decode_times=False
+                vertical_chunks[0][2], decode_times=False
             )
         else:
             ds_list = [
-                xr.open_dataset(path, decode_times=False)
-                for path in vertical_chunks
+                xr.open_dataset(path, decode_times=False, chunks={'time': 1})
+                for (_i0, _i1, path) in vertical_chunks
             ]
+            logger.info(
+                f'Concatenating {len(ds_list)} vertical chunks along time...'
+            )
             ds_final_in = xr.concat(ds_list, dim='time', join='exact')
+            logger.info('Concatenation complete.')
 
         _finalize_output_with_grid_ds(
             ds_final_in,
@@ -540,41 +568,266 @@ def _process_task(
         else:
             logger.info('Keeping intermediate files and namelists.')
 
+    # ds_meta closed automatically by context manager above
 
-def _run_exe(exe: str, namelist: str, logger, phase: str) -> None:
-    # Fortran executables expect the namelist file path as argv(1)
-    # Stream output live so progress appears in job logs.
+
+def _run_exe_capture(
+    exe: str, namelist: str, log_path: str, phase: str
+) -> None:
+    """Run a Fortran executable capturing stdout/stderr to a log file."""
     cmd = [exe, namelist]
-    # On Linux, stdbuf can force line-buffered output for streaming
-    try:
-        if shutil.which('stdbuf') is not None:
-            cmd = ['stdbuf', '-oL', '-eL'] + cmd
-    except Exception:
-        # If detection fails, proceed without stdbuf
-        pass
+    if shutil.which('stdbuf') is not None:
+        # Disable buffering to get near real-time output
+        cmd = ['stdbuf', '-o0', '-e0'] + cmd
 
-    logger.info(f'Running {phase} extrapolation executable: {" ".join(cmd)}')
+    env = os.environ.copy()
+    # Avoid oversubscription when multiple workers run BLAS/OMP code
+    env.setdefault('OMP_NUM_THREADS', '1')
+    env.setdefault('OPENBLAS_NUM_THREADS', '1')
+    env.setdefault('MKL_NUM_THREADS', '1')
 
-    try:
+    # Ensure log directory exists
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(log_path, 'a', encoding='utf-8') as lf:
+        lf.write(f'== Phase: {phase} ==\n')
+        lf.write(f'Command: {" ".join(cmd)}\n')
+        lf.flush()
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            env=env,
         )
         assert proc.stdout is not None
         for line in proc.stdout:
-            logger.info(line.rstrip())
+            lf.write(line)
+            lf.flush()
         proc.stdout.close()
         rc = proc.wait()
-        if rc != 0:  # pragma: no cover
+        if rc != 0:
             raise subprocess.CalledProcessError(rc, cmd)
-    except subprocess.CalledProcessError as e:  # pragma: no cover
-        logger.error(
-            f'Execution failed for {exe} (phase={phase}) rc={e.returncode}'
+
+
+def _execute_time_chunks(
+    *,
+    task: FileTask,
+    grid_file: str,
+    basin_file: str,
+    topo_file: str,
+    time_indices: List[Tuple[int, int]],
+    horiz_exec: str,
+    vert_exec: str,
+    num_workers: int,
+    has_time: bool,
+    logger,
+) -> List[Tuple[int, int, str]]:
+    """Execute time chunks serially or in parallel and return outputs."""
+    vertical_chunks: List[Tuple[int, int, str]] = []
+
+    if num_workers <= 1:
+        for i0, i1 in time_indices:
+            if i1 == 0:
+                continue
+            logger.info(f'  Submitting chunk {i0}:{i1} (serial)')
+            tup = _run_chunk_worker(
+                i0=i0,
+                i1=i1,
+                in_path=task.in_path,
+                grid_file=grid_file,
+                basin_file=basin_file,
+                topo_file=topo_file,
+                variable=task.variable,
+                tmp_dir=task.tmp_dir,
+                horiz_exec=horiz_exec,
+                vert_exec=vert_exec,
+                has_time=has_time,
+            )
+            vertical_chunks.append(tup)
+            logger.info(
+                f'  Completed chunk {i0}:{i1} -> {os.path.basename(tup[2])}'
+            )
+        return vertical_chunks
+
+    # Parallel execution
+    logger.info(
+        f'Launching {min(num_workers, len(time_indices))} workers for '
+        f'{len(time_indices)} chunks'
+    )
+    futures = []
+    fut_to_idx: dict = {}
+    with ProcessPoolExecutor(
+        max_workers=num_workers, mp_context=mp.get_context('spawn')
+    ) as ex:
+        for i0, i1 in time_indices:
+            if i1 == 0:
+                continue
+            logger.info(f'  Submitting chunk {i0}:{i1}')
+            fut = ex.submit(
+                _run_chunk_worker,
+                i0=i0,
+                i1=i1,
+                in_path=task.in_path,
+                grid_file=grid_file,
+                basin_file=basin_file,
+                topo_file=topo_file,
+                variable=task.variable,
+                tmp_dir=task.tmp_dir,
+                horiz_exec=horiz_exec,
+                vert_exec=vert_exec,
+                has_time=has_time,
+            )
+            futures.append(fut)
+            fut_to_idx[fut] = (i0, i1)
+        try:
+            for fut in as_completed(futures):
+                try:
+                    tup = fut.result()
+                except ChunkFailed as ce:
+                    for f in futures:
+                        f.cancel()
+                    logger.error(str(ce))
+                    raise
+                except Exception as e:
+                    # Unexpected worker exception; include chunk indices
+                    # if known
+                    i0i1 = fut_to_idx.get(fut, ('?', '?'))
+                    for f in futures:
+                        f.cancel()
+                    logger.error(
+                        f'Chunk {i0i1[0]}:{i0i1[1]} raised '
+                        f'{type(e).__name__}: {e}'
+                    )
+                    raise
+                else:
+                    vertical_chunks.append(tup)
+                    logger.info(
+                        f'  Completed chunk {tup[0]}:{tup[1]} -> '
+                        f'{os.path.basename(tup[2])}'
+                    )
+        except BrokenProcessPool as e:
+            # Infer completed chunks from presence of output files
+            done_set = set()
+            for i0, i1 in time_indices:
+                vertical_tmp = os.path.join(
+                    task.tmp_dir, f'vertical_{i0}_{i1}.nc'
+                )
+                if os.path.exists(vertical_tmp):
+                    done_set.add((i0, i1))
+            pending_set = set(time_indices) - done_set
+            logger.error(
+                'Worker pool crashed: '
+                f'{e}. Completed: {sorted(done_set)}; '
+                f'pending/unknown: {sorted(pending_set)}. '
+                'Check per-chunk logs under '
+                f'{os.path.join(task.tmp_dir, "logs")}.'
+            )
+            raise
+    return vertical_chunks
+
+
+def _run_chunk_worker(
+    *,
+    i0: int,
+    i1: int,
+    in_path: str,
+    grid_file: str,
+    basin_file: str,
+    topo_file: str,
+    variable: str,
+    tmp_dir: str,
+    horiz_exec: str,
+    vert_exec: str,
+    has_time: bool,
+) -> Tuple[int, int, str]:
+    """Process a single time chunk and return (i0, i1, vertical_tmp_path)."""
+    log_dir = os.path.join(tmp_dir, 'logs')
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, f'{variable}_t{i0}-{i1}.log')
+
+    # Prepare per-chunk input file and write logs into the chunk log
+    input_chunk = os.path.join(tmp_dir, f'input_{i0}_{i1}.nc')
+    horizontal_tmp = os.path.join(tmp_dir, f'horizontal_{i0}_{i1}.nc')
+    vertical_tmp = os.path.join(tmp_dir, f'vertical_{i0}_{i1}.nc')
+
+    # Enable faulthandler to capture fatal errors (e.g., segfault) to the log
+    fh_fault = open(log_path, 'a', encoding='utf-8')
+    try:
+        fh_fault.write('== faulthandler enabled ==\n')
+        fh_fault.flush()
+        faulthandler.enable(file=fh_fault, all_threads=True)
+    except Exception:
+        # Don't fail if faulthandler can't be enabled; continue
+        pass
+
+    try:
+        # Phase: prepare
+        chunk_logger = logging.getLogger(f'{__name__}.chunk.{i0}_{i1}')
+        chunk_logger.setLevel(logging.INFO)
+        fh = logging.FileHandler(log_path, mode='a', encoding='utf-8')
+        fh.setFormatter(
+            logging.Formatter('%(asctime)s %(levelname)s: %(message)s')
         )
-        raise
+        chunk_logger.addHandler(fh)
+        try:
+            if not os.path.exists(input_chunk):
+                chunk_logger.info('== Phase: prepare_input ==')
+                _prepare_input_with_coords(
+                    in_path,
+                    grid_file,
+                    input_chunk,
+                    variable,
+                    time_slice=(i0, i1) if has_time else None,
+                    logger=chunk_logger,
+                )
+            # Render a per-chunk namelist after paths are defined
+            namelist_contents = _render_namelist(
+                file_in=input_chunk,
+                horizontal_out=horizontal_tmp,
+                vertical_out=vertical_tmp,
+                basin_file=basin_file,
+                topo_file=topo_file,
+                variable=variable,
+            )
+            namelist_path = os.path.join(tmp_dir, f'{variable}_{i0}_{i1}.nml')
+            with open(namelist_path, 'w', encoding='utf-8') as f:
+                f.write(namelist_contents)
+        finally:
+            chunk_logger.removeHandler(fh)
+            fh.close()
+
+        # Phase: executables
+        if not os.path.exists(horizontal_tmp):
+            _run_exe_capture(horiz_exec, namelist_path, log_path, 'horizontal')
+        if not os.path.exists(vertical_tmp):
+            _run_exe_capture(vert_exec, namelist_path, log_path, 'vertical')
+
+        if not os.path.exists(vertical_tmp):
+            raise FileNotFoundError(
+                f'Expected vertical output missing: {vertical_tmp}'
+            )
+        return (i0, i1, vertical_tmp)
+    except BaseException as err:
+        # Append traceback to per-chunk log for easier debugging
+        try:
+            with open(log_path, 'a', encoding='utf-8') as lf:
+                lf.write('== Python exception ==\n')
+                lf.write(traceback.format_exc())
+        finally:
+            pass
+        raise ChunkFailed(
+            i0=i0, i1=i1, log_path=log_path, message=str(err)
+        ) from err
+    finally:
+        try:
+            faulthandler.disable()
+        except Exception:
+            pass
+        try:
+            fh_fault.close()
+        except Exception:
+            pass
 
 
 def _cleanup_intermediate(task: FileTask, logger) -> None:
@@ -599,6 +852,7 @@ def _prepare_input_with_coords(
     out_prepared_path: str,
     var_name: str,
     time_slice: tuple[int, int] | None = None,
+    logger: logging.Logger | None = None,
 ) -> None:
     """Ensure input has x/y coordinates; add from ISMIP grid if missing.
 
@@ -610,11 +864,20 @@ def _prepare_input_with_coords(
         )
         return
 
+    log = logger or logging.getLogger(__name__)
+
     ds_in = xr.open_dataset(in_path, chunks={'time': 1}, decode_times=False)
     if time_slice is not None and 'time' in ds_in.dims:
         i0, i1 = time_slice
         ds_in = ds_in.isel(time=slice(i0, i1))
     ds_grid = xr.open_dataset(grid_path, decode_times=False)
+
+    # Log dimensions early for debugging
+    dims_repr = ', '.join(f'{k}={v}' for k, v in ds_in.sizes.items())
+    log.info(
+        f'Prepared input initial dims after slice: {dims_repr} '
+        f"(var='{var_name}')"
+    )
 
     to_add = {}
     # Ensure dims exist and match sizes
@@ -636,6 +899,14 @@ def _prepare_input_with_coords(
     if to_add:
         ds_in = ds_in.assign(to_add)
 
+    # Validate target variable exists before dropping others
+    if var_name not in ds_in.variables:
+        available = ', '.join(sorted(ds_in.data_vars.keys()))
+        raise KeyError(
+            f"Variable '{var_name}' not found in input {in_path}. "
+            f'Available: {available}'
+        )
+
     # Keep only variables needed by the Fortran tools: the target variable
     # and essential coordinate variables (time, x, y, z or z_extrap)
     keep_vars = {var_name, 'time', 'x', 'y'}
@@ -648,12 +919,43 @@ def _prepare_input_with_coords(
     if drop_list:
         ds_in = ds_in.drop_vars(drop_list, errors='ignore')
 
+    # More logging: variable dims and dtype
+    v = ds_in[var_name]
+    v_dims = 'x'.join(str(s) for s in v.shape)
+    log.info(
+        f"Variable '{var_name}' shape after prep: {v_dims}, dtype={v.dtype}"
+    )
+
     # Ensure the target variable gets a fill value; others do not
-    write_netcdf(
-        ds_in,
-        out_prepared_path,
-        has_fill_values=lambda name, var: name == var_name,
-        progress_bar=True,
+    if time_slice is not None:
+        i0, i1 = time_slice
+        log.info(
+            f'Writing prepared input slice {i0}:{i1} to {out_prepared_path}'
+        )
+    else:
+        log.info(f'Writing prepared input to {out_prepared_path}')
+
+    # Use synchronous dask scheduler to avoid multi-threaded HDF5 I/O
+    log.info('Using dask scheduler: synchronous for to_netcdf')
+    with dask_config.set(scheduler='synchronous'):
+        write_netcdf(
+            ds_in,
+            out_prepared_path,
+            has_fill_values=lambda name, var: name == var_name,
+            format='NETCDF4',
+            engine='netcdf4',
+            progress_bar=False,
+        )
+
+    # Close datasets to release file handles and log completion
+    ds_in.close()
+    ds_grid.close()
+
+    size_bytes = os.path.getsize(out_prepared_path)
+    size_gb = size_bytes / (1024**3)
+    log.info(
+        f'Finished writing prepared input to {out_prepared_path} '
+        f'({size_gb:.2f} GiB)'
     )
 
 
@@ -669,9 +971,11 @@ def _finalize_output_with_grid_ds(
     This variant avoids creating a large concatenated temporary file by
     operating directly on a (possibly lazily concatenated) Dataset.
     """
+    logger.info(f'Finalizing output to {final_out_path}...')
     ds_out = ds_in
     ds_grid = xr.open_dataset(grid_path, decode_times=False)
 
+    logger.info('Injecting grid coordinates and variables into output...')
     coord_names = ['x', 'y']
     var_names = [
         'x_bnds',
@@ -699,6 +1003,8 @@ def _finalize_output_with_grid_ds(
         names = ', '.join(sorted(to_add_vars.keys()))
         logger.info(f'Overwriting grid variables in output: {names}')
         ds_out = ds_out.assign(to_add_vars)
+
+    logger.info('Writing final output NetCDF file...')
 
     write_netcdf(
         ds_out,

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -375,6 +375,7 @@ def _render_namelist(
         file_basin=basin_file,
         file_topo=topo_file,
         var_name=variable,
+        z_name='z_extrap',
     )
 
 

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -386,7 +386,7 @@ def _render_namelist(
         lstrip_blocks=True,
     )
     template = env.from_string(template_txt)
-    return template.render(
+    rendered = template.render(
         file_in=file_in,
         horizontal_out=horizontal_out,
         vertical_out=vertical_out,
@@ -395,6 +395,11 @@ def _render_namelist(
         var_name=variable,
         z_name='z_extrap',
     )
+    # Some Fortran compilers are picky if a namelist file doesn't end with a
+    # newline; ensure one exists.
+    if not rendered.endswith('\n'):
+        rendered = rendered + '\n'
+    return rendered
 
 
 def _process_task(

--- a/i7aof/extrap/cmip.py
+++ b/i7aof/extrap/cmip.py
@@ -327,7 +327,7 @@ def _prepare_paths_and_config(
     )
     out_dir = os.path.join(workdir, 'extrap', model, scenario, 'Omon', 'ct_sa')
     os.makedirs(out_dir, exist_ok=True)
-    ismip_res_str = get_res_string(config)
+    ismip_res_str = get_res_string(config, extrap=True)
     return config, workdir, remap_dir, out_dir, ismip_res_str, model_prefix
 
 

--- a/i7aof/extrap/namelist_template.nml.j2
+++ b/i7aof/extrap/namelist_template.nml.j2
@@ -9,6 +9,8 @@
   file_topo  = '{{ file_topo | default("__REQUIRED__") }}'
   ! REQUIRED: variable name to extrapolate (e.g. thetao, so)
   varnam     = '{{ var_name | default("__REQUIRED__") }}'
+  ! OPTIONAL: name of vertical dimension/coordinate variable
+  z_name     = '{{ z_name | default("z") }}'
 /
 
 &vertical_extrapolation
@@ -17,4 +19,6 @@
   ! REQUIRED: final vertically extrapolated output file
   file_out = '{{ vertical_out | default("__REQUIRED__") }}'
   varnam   = '{{ var_name | default("__REQUIRED__") }}'
+  ! OPTIONAL: name of vertical dimension/coordinate variable
+  z_name   = '{{ z_name | default("z") }}'
 /

--- a/i7aof/extrap/namelist_template.nml.j2
+++ b/i7aof/extrap/namelist_template.nml.j2
@@ -1,0 +1,20 @@
+&horizontal_extrapolation
+  ! REQUIRED: path to input CMIP6 file already on ISMIP6 grid
+  file_in    = '{{ file_in | default("__REQUIRED__") }}'
+  ! REQUIRED: output file produced by horizontal extrapolation (intermediate if vertical step follows)
+  file_out   = '{{ horizontal_out | default("tmp_hor.nc") }}'
+  ! REQUIRED: IMBIE2 basin numbers file
+  file_basin = '{{ file_basin | default("__REQUIRED__") }}'
+  ! REQUIRED: BedMachine / topography file
+  file_topo  = '{{ file_topo | default("__REQUIRED__") }}'
+  ! REQUIRED: variable name to extrapolate (e.g. thetao, so)
+  varnam     = '{{ var_name | default("__REQUIRED__") }}'
+/
+
+&vertical_extrapolation
+  ! REQUIRED: input file is usually the horizontal output
+  file_in  = '{{ horizontal_out | default("tmp_hor.nc") }}'
+  ! REQUIRED: final vertically extrapolated output file
+  file_out = '{{ vertical_out | default("__REQUIRED__") }}'
+  varnam   = '{{ var_name | default("__REQUIRED__") }}'
+/

--- a/i7aof/grid/ismip.py
+++ b/i7aof/grid/ismip.py
@@ -90,7 +90,7 @@ def get_horiz_res_string(config):
     return res
 
 
-def get_ver_res_string(config):
+def get_ver_res_string(config, extrap: bool = False):
     """
     Get the vertical resolution string from the configuration.
 
@@ -98,6 +98,8 @@ def get_ver_res_string(config):
     ----------
     config : mpas_tools.config.MpasConfigParser
         Configuration object with grid parameters.
+    extrap : bool, optional
+        If True, use ``dz_extrap`` instead of ``dz`` for the resolution.
 
     Returns
     -------
@@ -105,14 +107,15 @@ def get_ver_res_string(config):
         The vertical resolution as a string.
     """
     section = config['ismip_grid']
-    vres = section.getfloat('dz')
+    key = 'dz_extrap' if extrap else 'dz'
+    vres = section.getfloat(key)
     if vres == int(vres):
         vres = int(vres)
     res = f'{vres}m'
     return res
 
 
-def get_res_string(config):
+def get_res_string(config, extrap: bool = False):
     """
     Get the resolution string from the configuration.
 
@@ -120,6 +123,9 @@ def get_res_string(config):
     ----------
     config : mpas_tools.config.MpasConfigParser
         Configuration object with grid parameters.
+    extrap : bool, optional
+        If True, use ``dz_extrap`` for the vertical component of the
+        resolution string.
 
     Returns
     -------
@@ -128,7 +134,7 @@ def get_res_string(config):
         resolutions.
     """
     hres = get_horiz_res_string(config)
-    vres = get_ver_res_string(config)
+    vres = get_ver_res_string(config, extrap=extrap)
     return f'{hres}_{vres}'
 
 

--- a/i7aof/remap/cmip.py
+++ b/i7aof/remap/cmip.py
@@ -176,7 +176,7 @@ def _load_config_and_paths(
     os.makedirs(outdir, exist_ok=True)
     os.chdir(workdir)
 
-    ismip_res_str = get_res_string(config)
+    ismip_res_str = get_res_string(config, extrap=True)
     return config, workdir, outdir, ismip_res_str, model_prefix
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 # dependencies that are available on PyPI, a subset of those on conda-forge
 dependencies = [
     "cmocean",
+    "dask",
     "gsw",
     "inpoly",
     "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
 include = ["i7aof*"]
 
 [tool.setuptools.package-data]
-i7aof = ["*.cfg", "**/*.cfg"]
+i7aof = ["*.cfg", "**/*.cfg", "**/*.nml.j2"]
 
 [project.scripts]
 ismip7-antarctic-ocean-forcing = "i7aof.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "cmocean",
     "gsw",
     "inpoly",
+    "jinja2",
     "matplotlib",
     "netcdf4",
     "numpy",
@@ -55,6 +56,7 @@ i7aof = ["*.cfg", "**/*.cfg", "**/*.nml.j2"]
 ismip7-antarctic-ocean-forcing = "i7aof.__main__:main"
 ismip7-antarctic-convert-cmip = "i7aof.convert.cmip:main"
 ismip7-antarctic-remap-cmip = "i7aof.remap.cmip:main"
+ismip7-antarctic-extrap-cmip = "i7aof.extrap.cmip:main"
 
 [tool.setuptools.dynamic]
 version = { attr = "i7aof.version.__version__" }

--- a/scripts/test_extrap_cmip.cfg
+++ b/scripts/test_extrap_cmip.cfg
@@ -1,0 +1,14 @@
+## the working directory
+[workdir]
+# base working directory
+# Use the same workdir previously used for convert and remap so the extrap
+# step can find remapped ct/sa files under remap/<model>/<scenario>/Omon/ct_sa
+base_dir = /lcrc/group/e3sm/ac.xylar/test_ismip7_remap_cmip
+
+# Optional: select ISMIP grid resolution if you want to override defaults
+# [grid]
+# ismip_res = 4km
+
+# Optional: keep intermediate files (horizontal tmp + namelist)
+# [extrap]
+# keep_intermediate = true

--- a/scripts/test_extrap_cmip.py
+++ b/scripts/test_extrap_cmip.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import os
+
+from i7aof.extrap.cmip import extrap_cmip
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+config_filename = os.path.join(this_dir, 'test_extrap_cmip.cfg')
+
+# Assumes the convert and remap workflows have already been run in the same
+# work directory referenced by test_extrap_cmip.cfg.
+extrap_cmip(
+    model='CESM2-WACCM',
+    scenario='historical',
+    user_config_filename=config_filename,
+)


### PR DESCRIPTION
This pull request introduces Fortran-based horizontal and vertical extrapolation executables to the project, integrates them into the Conda build process, and updates documentation and developer workflows accordingly. Users and developers are now required to build and install these Fortran tools locally until a conda-forge package is available. The Python package and documentation have been updated to reflect this new dependency and workflow.

A new workflow for extrapolating CMIP datasets has also been introduced, along with a command-line tool for running it.

**Fortran Extrapolation Executables Integration:**

- Added CMake-based build system (`CMakeLists.txt`) and documentation for building Fortran extrapolation tools (`i7aof_extrap_horizontal` and `i7aof_extrap_vertical`). These tools are now required for the extrapolation workflow, with licensing clarified in a new `LICENSE-extrap` file. [[1]](diffhunk://#diff-b03c5521fc6db96aa83ef52529673541f4d612d0870c7cc14d51b8617b1b81c1R1-R93) [[2]](diffhunk://#diff-7025a22fb3819c453ff8088f9e76be7374d52b743dc78022b96b8a75c894a485R1-R54) [[3]](diffhunk://#diff-f9be12aa6b3ba71213320ff712c1b976c38e98f35124ad1919c32eb45a0ea51fR1-R21)
- Introduced a Conda recipe (`conda/recipe.yaml`) and build script (`conda/build.sh`) to compile and install the Fortran executables alongside the Python package, ensuring the tools are available in the user's environment. [[1]](diffhunk://#diff-5a5a6cfcb231569402fc1c22ff43c8d062e28cf680c7afda6c3458b8118ca971R1-R80) [[2]](diffhunk://#diff-d0038a34a760ab895199cb2e0f85c7a393e68a17ca1246bb8bfe5691cc045b47R1-R14)

**Developer and User Workflow Updates:**

- Updated the main `README.md` and developer guide (`docs/dev/contributing.md`) with step-by-step instructions for building, installing, and testing the Fortran executables locally using `rattler-build` and Conda, until a conda-forge package is published. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R74) [[2]](diffhunk://#diff-77427b00199d45ca27f2bd25934e2348693fada0e1e8b25986b7a2c388bce01eR31-R130)
- Added troubleshooting notes and guidance for rebuilding the Fortran tools after source changes in the developer documentation.

**Documentation and API Index Improvements:**

- Updated package and API documentation to reflect the new `i7aof.extrap` module and its dependencies. [[1]](diffhunk://#diff-b22963397050e8cb1bdc0a54badf43bd4abfd087379aa2c9db369d704a662f3fR10) [[2]](diffhunk://#diff-363e82493e2e04f41b234969fa9b7e9fe40d2a09b746ff381162a71206632657R15)

**Dependency Management:**

- Updated development environment specification (`dev-spec.txt`) to include new dependencies required by the extrapolation workflow.