### PR TITLE
Fix vertical resampling, backfill, and TEOS-10 coordinate handling

### DIFF
--- a/fortran/extrapolate_remaining_vertically.f90
+++ b/fortran/extrapolate_remaining_vertically.f90
@@ -194,7 +194,9 @@ DO kt=1,mtime
   enddo
   enddo
 
-  DO kz=3,mz
+  ! Start at kz=2 so a valid surface layer can seed the first subsurface
+  ! layer; otherwise a profile with only k=1 populated never propagates.
+  DO kz=2,mz
     do ki=1,mx
     do kj=1,my
       if ( var_in(ki,kj,kz) == miss .and. var_in(ki,kj,kz-1) /= miss ) then

--- a/i7aof/convert/teos10.py
+++ b/i7aof/convert/teos10.py
@@ -440,6 +440,61 @@ def _normalize_lon(lon: xr.DataArray) -> xr.DataArray:
     return lon_out
 
 
+def _get_and_validate_positive(
+    coord: xr.DataArray, coord_name: str, positive: str | None = None
+) -> str | None:
+    """Resolve and validate the effective ``positive`` direction."""
+    if positive is None:
+        positive = coord.attrs.get('positive')
+    if positive is not None:
+        positive = positive.lower()
+
+    values = np.asarray(coord.values)
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return positive
+
+    finite = finite.reshape(-1)
+    inferred = None
+    if finite.size > 1:
+        inferred = 'down' if finite[-1] > finite[0] else 'up'
+    elif finite[0] > 0:
+        inferred = 'down'
+    elif finite[0] < 0:
+        inferred = 'up'
+
+    if positive is None:
+        return inferred
+
+    if positive not in ('up', 'down'):
+        return positive
+
+    if finite.size == 1:
+        if positive == 'up' and finite[0] > 0:
+            raise ValueError(
+                f"{coord_name} has positive='up' but value {finite[0]} is "
+                'positive.'
+            )
+        if positive == 'down' and finite[0] < 0:
+            raise ValueError(
+                f"{coord_name} has positive='down' but value {finite[0]} is "
+                'negative.'
+            )
+        return positive
+
+    if positive == 'up' and finite[-1] > finite[0]:
+        raise ValueError(
+            f"{coord_name} has positive='up' but increases with index: "
+            f'first={finite[0]}, last={finite[-1]}.'
+        )
+    if positive == 'down' and finite[-1] < finite[0]:
+        raise ValueError(
+            f"{coord_name} has positive='down' but decreases with index: "
+            f'first={finite[0]}, last={finite[-1]}.'
+        )
+    return positive
+
+
 def _depth_to_z(
     depth: xr.DataArray, positive: str | None = None
 ) -> xr.DataArray:
@@ -459,12 +514,7 @@ def _depth_to_z(
         TEOS-10 z coordinate (m, negative downward) with units and
         long_name attributes set.
     """
-    if positive is None:
-        positive = depth.attrs.get('positive')
-        if positive is not None:
-            positive = positive.lower()
-        elif depth.size > 1:
-            positive = 'down' if depth.values[-1] > depth.values[0] else 'up'
+    positive = _get_and_validate_positive(depth, 'depth', positive=positive)
     units = depth.attrs.get('units', '').lower()
     # Handle units and convert to meters if necessary (assume meters if
     # unit-less)
@@ -507,7 +557,7 @@ def _pressure_from_z(z_or_p: xr.DataArray, lat: xr.DataArray) -> np.ndarray:
     """
     # Ensure z uses the TEOS-10 convention: negative below sea level.
     z = z_or_p
-    positive_attr = z.attrs.get('positive', '').lower()
+    positive_attr = _get_and_validate_positive(z, 'z')
     z_min = z.min(skipna=True)
     z_max = z.max(skipna=True)
     z_is_nonnegative = bool(z_min.item() >= 0) if z_min.size == 1 else False

--- a/i7aof/convert/teos10.py
+++ b/i7aof/convert/teos10.py
@@ -598,10 +598,17 @@ def _pressure_from_z(z_or_p: xr.DataArray, lat: xr.DataArray) -> np.ndarray:
     # Prefer the numeric sign over metadata because some inputs carry
     # depth-style attrs even after being converted to negative TEOS-10 z.
     # Mixed-sign arrays can legitimately span sea level in TEOS-10
-    # convention, so only flip numerically depth-like inputs.
+    # convention, so only flip numerically depth-like inputs. However,
+    # reject metadata that claims TEOS-10 "positive=up" when the values are
+    # clearly depth-like, because passing positive depths into p_from_z
+    # would silently produce incorrect pressures.
     should_flip = z_is_nonnegative and not z_is_nonpositive
-    if positive_attr == 'up':
-        should_flip = False
+    if positive_attr == 'up' and should_flip:
+        raise ValueError(
+            "vertical coordinate values disagree with positive='up': finite "
+            'values are depth-like (nonnegative) but TEOS-10 z must be '
+            'nonpositive below sea level.'
+        )
     if should_flip:
         attrs = z.attrs.copy()
         z = -z

--- a/i7aof/convert/teos10.py
+++ b/i7aof/convert/teos10.py
@@ -463,6 +463,8 @@ def _depth_to_z(
         positive = depth.attrs.get('positive')
         if positive is not None:
             positive = positive.lower()
+        elif depth.size > 1:
+            positive = 'down' if depth.values[-1] > depth.values[0] else 'up'
     units = depth.attrs.get('units', '').lower()
     # Handle units and convert to meters if necessary (assume meters if
     # unit-less)
@@ -488,7 +490,10 @@ def _depth_to_z(
 
     z = z.assign_attrs(
         units='m',
+        positive='up',
+        standard_name='height',
         long_name='height above mean sea level',
+        axis='Z',
     )
     return z
 
@@ -500,11 +505,19 @@ def _pressure_from_z(z_or_p: xr.DataArray, lat: xr.DataArray) -> np.ndarray:
     NumPy array of pressure suitable for passing to gsw functions. Handles
     broadcasting to (Z,Y,X) for common input shapes.
     """
-    # Ensure z is TEOS-10 z (negative downward)
+    # Ensure z uses the TEOS-10 convention: negative below sea level.
     z = z_or_p
-    if (z.min() >= 0).item() or (
-        z.attrs.get('positive', '').lower() == 'down'
-    ):
+    positive_attr = z.attrs.get('positive', '').lower()
+    z_min = z.min(skipna=True)
+    z_max = z.max(skipna=True)
+    z_is_nonnegative = bool(z_min.item() >= 0) if z_min.size == 1 else False
+    z_is_nonpositive = bool(z_max.item() <= 0) if z_max.size == 1 else False
+    # Prefer the numeric sign over metadata because some inputs carry
+    # depth-style attrs even after being converted to negative TEOS-10 z.
+    should_flip = z_is_nonnegative
+    if positive_attr == 'down' and not z_is_nonpositive:
+        should_flip = True
+    if should_flip:
         attrs = z.attrs.copy()
         z = -z
         attrs['positive'] = 'up'

--- a/i7aof/convert/teos10.py
+++ b/i7aof/convert/teos10.py
@@ -440,8 +440,19 @@ def _normalize_lon(lon: xr.DataArray) -> xr.DataArray:
     return lon_out
 
 
+def _scalar_reduction(value: xr.DataArray):
+    """Convert a scalar xarray reduction result into a Python scalar."""
+    value_np = np.asarray(value.values)
+    if value_np.size != 1:
+        raise ValueError('Expected a scalar reduction result.')
+    return value_np.item()
+
+
 def _get_and_validate_positive(
-    coord: xr.DataArray, coord_name: str, positive: str | None = None
+    coord: xr.DataArray,
+    coord_name: str,
+    positive: str | None = None,
+    validation_dim: str | None = None,
 ) -> str | None:
     """Resolve and validate the effective ``positive`` direction."""
     if positive is None:
@@ -449,19 +460,37 @@ def _get_and_validate_positive(
     if positive is not None:
         positive = positive.lower()
 
-    values = np.asarray(coord.values)
-    finite = values[np.isfinite(values)]
-    if finite.size == 0:
-        return positive
-
-    finite = finite.reshape(-1)
     inferred = None
-    if finite.size > 1:
-        inferred = 'down' if finite[-1] > finite[0] else 'up'
-    elif finite[0] > 0:
-        inferred = 'down'
-    elif finite[0] < 0:
-        inferred = 'up'
+    if validation_dim is None and coord.ndim == 1:
+        validation_dim = coord.dims[0]
+    if validation_dim is not None and validation_dim not in coord.dims:
+        raise ValueError(
+            f"{coord_name} validation dimension '{validation_dim}' is not "
+            'present in the coordinate.'
+        )
+
+    has_increase = False
+    has_decrease = False
+    if validation_dim is not None and coord.sizes[validation_dim] > 1:
+        first = coord.isel({validation_dim: 0})
+        last = coord.isel({validation_dim: -1})
+        delta = (last - first).where(np.isfinite(first) & np.isfinite(last))
+        has_increase = bool(_scalar_reduction((delta > 0).any()))
+        has_decrease = bool(_scalar_reduction((delta < 0).any()))
+        if has_increase and not has_decrease:
+            inferred = 'down'
+        elif has_decrease and not has_increase:
+            inferred = 'up'
+
+    coord_min = _scalar_reduction(coord.min(skipna=True))
+    coord_max = _scalar_reduction(coord.max(skipna=True))
+    if np.isfinite(coord_min) and np.isfinite(coord_max):
+        if inferred is None and coord_min > 0:
+            inferred = 'down'
+        elif inferred is None and coord_max < 0:
+            inferred = 'up'
+    else:
+        return positive
 
     if positive is None:
         return inferred
@@ -469,28 +498,25 @@ def _get_and_validate_positive(
     if positive not in ('up', 'down'):
         return positive
 
-    if finite.size == 1:
-        if positive == 'up' and finite[0] > 0:
-            raise ValueError(
-                f"{coord_name} has positive='up' but value {finite[0]} is "
-                'positive.'
-            )
-        if positive == 'down' and finite[0] < 0:
-            raise ValueError(
-                f"{coord_name} has positive='down' but value {finite[0]} is "
-                'negative.'
-            )
-        return positive
-
-    if positive == 'up' and finite[-1] > finite[0]:
+    if positive == 'up' and has_increase:
         raise ValueError(
-            f"{coord_name} has positive='up' but increases with index: "
-            f'first={finite[0]}, last={finite[-1]}.'
+            f"{coord_name} has positive='up' but increases along "
+            f'{validation_dim or "its vertical dimension"}.'
         )
-    if positive == 'down' and finite[-1] < finite[0]:
+    if positive == 'down' and has_decrease:
         raise ValueError(
-            f"{coord_name} has positive='down' but decreases with index: "
-            f'first={finite[0]}, last={finite[-1]}.'
+            f"{coord_name} has positive='down' but decreases along "
+            f'{validation_dim or "its vertical dimension"}.'
+        )
+    if positive == 'up' and coord_min > 0:
+        raise ValueError(
+            f"{coord_name} has positive='up' but all finite values are "
+            'positive.'
+        )
+    if positive == 'down' and coord_max < 0:
+        raise ValueError(
+            f"{coord_name} has positive='down' but all finite values are "
+            'negative.'
         )
     return positive
 
@@ -514,7 +540,12 @@ def _depth_to_z(
         TEOS-10 z coordinate (m, negative downward) with units and
         long_name attributes set.
     """
-    positive = _get_and_validate_positive(depth, 'depth', positive=positive)
+    positive = _get_and_validate_positive(
+        depth,
+        'depth',
+        positive=positive,
+        validation_dim=depth.dims[0] if depth.dims else None,
+    )
     units = depth.attrs.get('units', '').lower()
     # Handle units and convert to meters if necessary (assume meters if
     # unit-less)
@@ -557,16 +588,20 @@ def _pressure_from_z(z_or_p: xr.DataArray, lat: xr.DataArray) -> np.ndarray:
     """
     # Ensure z uses the TEOS-10 convention: negative below sea level.
     z = z_or_p
-    positive_attr = _get_and_validate_positive(z, 'z')
-    z_min = z.min(skipna=True)
-    z_max = z.max(skipna=True)
-    z_is_nonnegative = bool(z_min.item() >= 0) if z_min.size == 1 else False
-    z_is_nonpositive = bool(z_max.item() <= 0) if z_max.size == 1 else False
+    positive_attr = z.attrs.get('positive')
+    if positive_attr is not None:
+        positive_attr = positive_attr.lower()
+    z_min = _scalar_reduction(z.min(skipna=True))
+    z_max = _scalar_reduction(z.max(skipna=True))
+    z_is_nonnegative = np.isfinite(z_min) and z_min >= 0
+    z_is_nonpositive = np.isfinite(z_max) and z_max <= 0
     # Prefer the numeric sign over metadata because some inputs carry
     # depth-style attrs even after being converted to negative TEOS-10 z.
-    should_flip = z_is_nonnegative
-    if positive_attr == 'down' and not z_is_nonpositive:
-        should_flip = True
+    # Mixed-sign arrays can legitimately span sea level in TEOS-10
+    # convention, so only flip numerically depth-like inputs.
+    should_flip = z_is_nonnegative and not z_is_nonpositive
+    if positive_attr == 'up':
+        should_flip = False
     if should_flip:
         attrs = z.attrs.copy()
         z = -z

--- a/i7aof/vert/resamp.py
+++ b/i7aof/vert/resamp.py
@@ -104,7 +104,7 @@ class VerticalResampler:
         data_valid = da.notnull()
         valid = base_valid & data_valid
         valid_weight = valid.astype(da.dtype)
-        da_masked = da.where(valid, other=0.0)
+        da_masked = da.where(valid, other=xr.zeros_like(da))
 
         # Numerator and denominator via weighted sums over src vertical dim.
         weights = self.weights

--- a/i7aof/vert/resamp.py
+++ b/i7aof/vert/resamp.py
@@ -96,19 +96,22 @@ class VerticalResampler:
                 f"'{src}'. Dims: {da.dims}"
             )
 
-        # Build a validity mask aligned to da (broadcast src_valid if needed)
-        valid = self.src_valid
-        # If valid has no time dim but da does, xarray will broadcast
-        valid = valid.astype(da.dtype)
+        # Build a validity mask aligned to da (broadcast src_valid if needed).
+        # Missing source values need to be excluded from both numerator and
+        # denominator; otherwise a single NaN in any overlapping fine layer
+        # contaminates the whole coarse layer.
+        base_valid = self.src_valid.astype(bool)
+        data_valid = da.notnull()
+        valid = base_valid & data_valid
+        valid_weight = valid.astype(da.dtype)
+        da_masked = da.where(valid, other=0.0)
 
-        # Numerator and denominator via weighted sums over src vertical dim
-        # weights dims: (src, dst). Use xr.dot over the shared 'src' dim.
-        # Align weight dims for dot: ensure name matches
+        # Numerator and denominator via weighted sums over src vertical dim.
         weights = self.weights
 
         # Sum over source layers: (other_dims, dst)
-        num = xr.dot(da * valid, weights, dims=src)
-        denom = xr.dot(valid, weights, dims=src)
+        num = xr.dot(da_masked, weights, dims=src)
+        denom = xr.dot(valid_weight, weights, dims=src)
 
         # Coverage fraction relative to destination thickness
         frac = denom / self.dz_dst

--- a/tests/test_teos10.py
+++ b/tests/test_teos10.py
@@ -1,0 +1,65 @@
+import gsw
+import numpy as np
+import pytest
+import xarray as xr
+
+from i7aof.convert.teos10 import (
+    _get_and_validate_positive,
+    _pressure_from_z,
+)
+
+
+def test_get_and_validate_positive_uses_vertical_dimension() -> None:
+    coord = xr.DataArray(
+        np.array(
+            [
+                [[50.0, 0.0], [50.0, 0.0]],
+                [[100.0, 50.0], [100.0, 50.0]],
+            ]
+        ),
+        dims=('lev', 'y', 'x'),
+    )
+
+    positive = _get_and_validate_positive(coord, 'depth', validation_dim='lev')
+
+    assert positive == 'down'
+
+
+def test_pressure_from_z_ignores_stale_positive_down_metadata() -> None:
+    z = xr.DataArray(
+        np.array([-5.0, -50.0]),
+        dims=('lev',),
+        attrs={'positive': 'down'},
+    )
+    lat = xr.DataArray(np.array([-70.0]), dims=('y',))
+
+    pressure = _pressure_from_z(z, lat)
+    expected = gsw.p_from_z(z.values[:, None, None], lat.values[:, None])
+
+    np.testing.assert_allclose(pressure, expected)
+
+
+def test_pressure_from_z_does_not_flip_mixed_sign_teos10_z() -> None:
+    z = xr.DataArray(
+        np.array([10.0, -10.0]),
+        dims=('lev',),
+        attrs={'positive': 'down'},
+    )
+    lat = xr.DataArray(np.array([-70.0]), dims=('y',))
+
+    pressure = _pressure_from_z(z, lat)
+    expected = gsw.p_from_z(z.values[:, None, None], lat.values[:, None])
+
+    np.testing.assert_allclose(pressure, expected)
+
+
+def test_pressure_from_z_rejects_positive_up_with_depth_like_values() -> None:
+    z = xr.DataArray(
+        np.array([5.0, 50.0]),
+        dims=('lev',),
+        attrs={'positive': 'up'},
+    )
+    lat = xr.DataArray(np.array([-70.0]), dims=('y',))
+
+    with pytest.raises(ValueError, match="positive='up'"):
+        _pressure_from_z(z, lat)


### PR DESCRIPTION
This PR pulls the production bug fixes out of the `debug-vert-interp` work and leaves the debug-only instrumentation behind.

It fixes three issues in the vertical-processing path:

- exclude NaN source values from both the numerator and denominator in conservative vertical resampling, so partial overlap with missing data does not contaminate the entire destination layer
- start the downward backfill loop at the first subsurface layer in `extrapolate_remaining_vertically.f90`, which fixes profiles where only the surface layer is initially populated
- harden TEOS-10 vertical-coordinate handling by inferring missing `positive` metadata, preferring numeric sign over stale metadata when interpreting `z`, and raising a clear error when coordinate values and `positive` metadata disagree
