### PR TITLE
Biascorr: bias and model-climatology caches by future scenario

### DIFF
--- a/i7aof/biascorr/classic.py
+++ b/i7aof/biascorr/classic.py
@@ -295,7 +295,7 @@ def _compute_biases(
         clim_dir = build_cmip_final_dir(
             config,
             model=model,
-            scenario='historical',
+            scenario=future_scenario,
             variable=var,
             version=version,
             extras='climatology',
@@ -303,7 +303,7 @@ def _compute_biases(
         bias_dir = build_cmip_final_dir(
             config,
             model=model,
-            scenario='historical',
+            scenario=future_scenario,
             variable=var,
             version=version,
             extras='bias',
@@ -316,7 +316,7 @@ def _compute_biases(
             build_cmip_final_filename(
                 variable=var,
                 model=model,
-                scenario='historical',
+                scenario=future_scenario,
                 version=version,
                 year_range=year_range,
                 extras='climatology',
@@ -327,7 +327,7 @@ def _compute_biases(
             build_cmip_final_filename(
                 variable=var,
                 model=model,
-                scenario='historical',
+                scenario=future_scenario,
                 version=version,
                 year_range=year_range,
                 extras='bias',


### PR DESCRIPTION
When multiple future scenarios are processed in the same workdir, cached model climatology and bias files under final/.../extras/ were keyed with scenario='historical'. A second scenario could skip recomputation and reuse the first scenario’s bias. This change keys those paths with future_scenario so each SSP has its own cache.