### PR TITLE
Fix teos-10 test that should not have positive z value

### DIFF
--- a/tests/test_teos10.py
+++ b/tests/test_teos10.py
@@ -41,7 +41,7 @@ def test_pressure_from_z_ignores_stale_positive_down_metadata() -> None:
 
 def test_pressure_from_z_does_not_flip_mixed_sign_teos10_z() -> None:
     z = xr.DataArray(
-        np.array([10.0, -10.0]),
+        np.array([0.0, -10.0]),
         dims=('lev',),
         attrs={'positive': 'down'},
     )


### PR DESCRIPTION
A TEOS-10 test was added that had both positive and negative z values.  The positive values don't make sense and the `gsw` package seems to now be raising an error if they are present.