### PR TITLE
Update remapping for pyremap >=2.2.0

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -48,7 +48,7 @@ requirements:
     - requests
     - progressbar2
     - pyproj
-    - pyremap >=2.0.0,<3.0.0
+    - pyremap >=2.2.0,<3.0.0
     - pyshp
     - scikit-fmm
     - scipy

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -19,7 +19,7 @@ requests
 progressbar2
 dask
 pyproj
-pyremap >=2.0.0,<3.0.0
+pyremap >=2.2.0,<3.0.0
 pyshp
 scikit-fmm
 scipy

--- a/i7aof/convert/ct_sa_to_thetao_so.py
+++ b/i7aof/convert/ct_sa_to_thetao_so.py
@@ -317,6 +317,14 @@ def clim_ct_sa_to_thetao_so(
     grid_path = ensure_ismip_grid(config)
     outputs: List[str] = []
     for ct_path, sa_path in pairs:
+        # Stage the source ct/sa as final outputs alongside thetao/so/tf so
+        # all five climatology fields are published.
+        _publish_final_climatology(
+            config=config, clim_name=clim_name, var='ct', in_path=ct_path
+        )
+        _publish_final_climatology(
+            config=config, clim_name=clim_name, var='sa', in_path=sa_path
+        )
         out_thetao = _output_path_for_extrap_thetao(ct_path)
         out_so = _output_path_for_extrap_so(ct_path)
         thetao_exists = os.path.exists(out_thetao)

--- a/i7aof/default.cfg
+++ b/i7aof/default.cfg
@@ -13,7 +13,7 @@ final_dir = final
 ## output naming conventions
 [output]
 # version tag embedded in published filenames (e.g., v4, v5)
-version = v3
+version = v4
 
 
 ## config options related to the default ISMIP grid

--- a/i7aof/remap/__init__.py
+++ b/i7aof/remap/__init__.py
@@ -107,6 +107,7 @@ def remap_lat_lon_to_ismip(
     lon_var='lon',
     lat_var='lat',
     renormalize=None,
+    regional=None,
 ):
     """
     Remap a dataset on a lat-lon grid to the ISMIP grid, creating a mapping
@@ -137,6 +138,10 @@ def remap_lat_lon_to_ismip(
         'lat').
     renormalize : float, optional
         If provided, a threshold to use to renormalize the data
+    regional : bool, optional
+        Whether the source grid is regional. If ``None`` (the default),
+        pyremap determines this automatically from the lat/lon extent.
+        Pass ``False`` to force a global (periodic) source grid.
     """
     if os.path.exists(out_filename):
         return
@@ -171,6 +176,7 @@ def remap_lat_lon_to_ismip(
         mesh_name=in_grid_name,
         lon_var=lon_var,
         lat_var=lat_var,
+        regional=regional,
     )
     remapper.dst_from_proj(
         filename=ismip_grid_filename,
@@ -250,6 +256,57 @@ def add_periodic_lon(ds, threshold=1e-10, lon_var='lon', periodic_dim=None):
             lon[-1] = lon[0] + (2 * np.pi if rad else 360.0)
             ds[lon_var] = (periodic_dim, lon)
             ds[lon_var].attrs = attrs
+
+    return ds
+
+
+def drop_duplicate_lon(ds, threshold=1e-10, lon_var='lon'):
+    """
+    Drop a redundant duplicate longitude column from a 1D global lat/lon
+    grid.
+
+    Some global datasets (e.g. a climatology with longitude running from
+    -180 to +180 inclusive) include both the first and last longitude as the
+    same physical location. When such a grid is treated as global (periodic)
+    by ESMF, the duplicated seam produces a zero-width ("degenerate") cell and
+    weight generation fails. Dropping the final duplicate column yields a
+    well-formed periodic grid that pyremap (>=2.2.0) can detect as global.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset containing a 1D longitude variable.
+
+    threshold : float, optional
+        Tolerance (in degrees) for deciding that the longitude span between
+        the first and last cell centers is a full 360 degrees. Default is
+        1e-10.
+
+    lon_var : str, optional
+        The name of the longitude variable in the dataset. Default is 'lon'.
+
+    Returns
+    -------
+    xarray.Dataset
+        The dataset with a duplicate seam column removed if one was present;
+        otherwise the dataset is returned unchanged.
+    """
+    if len(ds[lon_var].dims) != 1:
+        raise ValueError(
+            f'Expected longitude variable "{lon_var}" to have 1 dimension, '
+            f'but got {len(ds[lon_var].dims)}.'
+        )
+
+    periodic_dim = ds[lon_var].dims[0]
+    lon = ds[lon_var].values
+    span = np.abs(lon[-1] - lon[0])
+    rad = 'rad' in ds[lon_var].attrs.get('units', '')
+    if rad:
+        span = np.rad2deg(span)
+
+    if np.abs(span - 360.0) <= threshold:
+        nperiodic_dim = ds.sizes[periodic_dim]
+        ds = ds.isel({periodic_dim: np.arange(nperiodic_dim - 1)})
 
     return ds
 

--- a/i7aof/remap/clim.py
+++ b/i7aof/remap/clim.py
@@ -119,9 +119,16 @@ def remap_climatology(
         config, in_filename, vert_tmpdir
     )
 
-    # 1) Vertical pipeline: masking -> vertical interpolation -> normalize
+    # 1) Vertical pipeline: masking -> vertical interpolation -> normalize.
+    # Mask whole columns wherever the climatology has no surface data so
+    # spurious ice-shelf-cavity columns are excluded from the remapping.
     vert_interp_filenames = _vert_mask_interp_norm_multi(
-        config, preprocessed, outdir, ['ct', 'sa'], vert_tmpdir
+        config,
+        preprocessed,
+        outdir,
+        ['ct', 'sa'],
+        vert_tmpdir,
+        mask_from_surface=True,
     )
 
     with LoggingContext(__name__) as logger:

--- a/i7aof/remap/shared.py
+++ b/i7aof/remap/shared.py
@@ -20,7 +20,7 @@ from i7aof.vert.interp import VerticalInterpolator, fix_src_z_coord
 
 
 def _vert_mask_interp_norm_multi(
-    config, in_filename, outdir, variables, tmpdir
+    config, in_filename, outdir, variables, tmpdir, mask_from_surface=False
 ):
     """
     Mask, vertically interpolate, and normalize variables to the ISMIP
@@ -45,6 +45,12 @@ def _vert_mask_interp_norm_multi(
     Time handling
     - Works with or without a ``time`` dimension. If time is present,
         stages are chunked by ``[remap_cmip] vert_time_chunk`` from config.
+
+    Surface masking
+    - When ``mask_from_surface`` is True, any column whose shallowest
+        (surface) layer is a fill value is treated as fully invalid. This
+        is used for observational climatologies whose ice-shelf-cavity
+        columns have data at depth but none at the surface.
 
     Returns
     - Absolute path to the final normalized file to feed the horizontal
@@ -74,7 +80,7 @@ def _vert_mask_interp_norm_multi(
     ds_ismip = read_dataset(get_ismip_grid_filename(config))
 
     lev, lev_bnds, src_valid = _prepare_vert_coords_and_mask(
-        in_filename, variables
+        in_filename, variables, mask_from_surface=mask_from_surface
     )
 
     time_chunk = config.getint('remap_cmip', 'vert_time_chunk')
@@ -121,7 +127,9 @@ def _vert_mask_interp_norm_multi(
     return normalized_filename
 
 
-def _prepare_vert_coords_and_mask(in_filename, variables):
+def _prepare_vert_coords_and_mask(
+    in_filename, variables, mask_from_surface=False
+):
     with read_dataset(in_filename) as ds:
         lev, lev_bnds = fix_src_z_coord(ds, 'lev', 'lev_bnds')
         ds = ds.assign_coords({'lev': ('lev', lev.data)})
@@ -135,6 +143,17 @@ def _prepare_vert_coords_and_mask(in_filename, variables):
             else:
                 valid = da.notnull()
             src_valid = valid if src_valid is None else (src_valid & valid)
+        if mask_from_surface:
+            # Wherever the surface (shallowest) layer is a fill value, treat
+            # the entire vertical column as invalid. This removes spurious
+            # ice-shelf-cavity columns that some climatologies represent with
+            # valid data at depth but no data at the surface. The surface is
+            # the level with the largest z (closest to the sea surface);
+            # fix_src_z_coord makes lev positive-up but does not sort it, so
+            # we locate the surface with argmax rather than assuming an order.
+            surface_idx = int(np.asarray(lev.values).argmax())
+            surface_valid = src_valid.isel(lev=surface_idx)
+            src_valid = src_valid & surface_valid
     return lev, lev_bnds, src_valid
 
 

--- a/i7aof/remap/shared.py
+++ b/i7aof/remap/shared.py
@@ -11,7 +11,11 @@ from i7aof.coords import (
 )
 from i7aof.grid.ismip import get_ismip_grid_filename
 from i7aof.io import ensure_cf_time_encoding, read_dataset, write_netcdf
-from i7aof.remap import add_periodic_lon, remap_lat_lon_to_ismip
+from i7aof.remap import (
+    add_periodic_lon,
+    drop_duplicate_lon,
+    remap_lat_lon_to_ismip,
+)
 from i7aof.vert.interp import VerticalInterpolator, fix_src_z_coord
 
 
@@ -251,6 +255,7 @@ def _run_remap_with_temp_cwd(
     lon_var,
     lat_var,
     renormalize=None,
+    regional=None,
 ):
     """Run remap_lat_lon_to_ismip inside a temporary working directory.
 
@@ -279,6 +284,8 @@ def _run_remap_with_temp_cwd(
         )
         if renormalize is not None:
             kwargs['renormalize'] = renormalize
+        if regional is not None:
+            kwargs['regional'] = regional
         remap_lat_lon_to_ismip(**kwargs)
         success = True
     finally:
@@ -333,8 +340,21 @@ def _remap_horiz(
         )
     in_grid_name = model_prefix
     ds = read_dataset(in_filename, chunks={'time': 1})
-    if method == 'bilinear':
-        ds = add_periodic_lon(ds, lon_var=lon_var, periodic_dim=x_dim)
+    # Longitude dimensionality determines how we treat the periodic seam:
+    # - 1D grids (e.g. observational climatologies spanning the full range of
+    #   longitude) are global. pyremap (>=2.2.0) treats them as periodic, so
+    #   we just drop a duplicate seam column (e.g. both -180 and +180 present)
+    #   to keep the global grid well-formed for ESMF.
+    # - 2D grids (e.g. the CESM POP tripole grid) are treated as regional, so
+    #   for bilinear remapping we instead close the seam by appending a
+    #   periodic column.
+    if len(ds[lon_var].dims) == 1:
+        regional = False
+        ds = drop_duplicate_lon(ds, lon_var=lon_var)
+    else:
+        regional = True
+        if method == 'bilinear':
+            ds = add_periodic_lon(ds, lon_var=lon_var, periodic_dim=x_dim)
     ds_mask = _build_and_remap_mask(
         ds=ds,
         tmpdir=tmpdir,
@@ -344,6 +364,7 @@ def _remap_horiz(
         logger=logger,
         lon_var=lon_var,
         lat_var=lat_var,
+        regional=regional,
     )
     remapped_chunks = _remap_data_variables(
         ds=ds,
@@ -356,6 +377,7 @@ def _remap_horiz(
         lat_var=lat_var,
         renorm_threshold=renorm_threshold,
         has_fill_values=has_fill_values,
+        regional=regional,
     )
     _validate_z_extrap(remapped_chunks)
     ds_final = _concat_chunks(remapped_chunks)
@@ -380,6 +402,7 @@ def _build_and_remap_mask(
     logger,
     lon_var: str,
     lat_var: str,
+    regional: bool | None = None,
 ) -> xr.Dataset:
     """Create and horizontally remap the src_frac_interp mask dataset."""
     input_mask_path = os.path.join(tmpdir, 'input_mask.nc')
@@ -411,6 +434,7 @@ def _build_and_remap_mask(
         lon_var=lon_var,
         lat_var=lat_var,
         renormalize=None,
+        regional=regional,
     )
     if not os.path.exists(output_mask_tmp):
         raise FileNotFoundError(
@@ -432,6 +456,7 @@ def _remap_data_variables(
     lat_var: str,
     renorm_threshold: float,
     has_fill_values: list[str],
+    regional: bool | None = None,
 ) -> list[xr.Dataset]:
     """Remap data variables in ds either single-pass or chunked in time."""
     if 'time' not in ds.dims:
@@ -446,6 +471,7 @@ def _remap_data_variables(
             lat_var,
             renorm_threshold,
             has_fill_values,
+            regional,
         )
     return _remap_with_time(
         ds,
@@ -458,6 +484,7 @@ def _remap_data_variables(
         lat_var,
         renorm_threshold,
         has_fill_values,
+        regional,
     )
 
 
@@ -534,6 +561,7 @@ def _remap_no_time(
     lat_var,
     renorm_threshold,
     has_fill_values,
+    regional=None,
 ):
     input_chunk_path = os.path.join(tmpdir, 'input_single.nc')
     output_chunk_path = os.path.join(tmpdir, 'output_single.nc')
@@ -566,6 +594,7 @@ def _remap_no_time(
         lon_var=lon_var,
         lat_var=lat_var,
         renormalize=renorm_threshold,
+        regional=regional,
     )
     if not os.path.exists(output_chunk_tmp):
         raise FileNotFoundError(
@@ -587,6 +616,7 @@ def _remap_with_time(
     lat_var,
     renorm_threshold,
     has_fill_values,
+    regional=None,
 ):
     chunk_size = config.getint('remap_cmip', 'horiz_time_chunk')
     n_time = ds.sizes['time']
@@ -647,6 +677,7 @@ def _remap_with_time(
             lon_var=lon_var,
             lat_var=lat_var,
             renormalize=renorm_threshold,
+            regional=regional,
         )
         if not os.path.exists(output_chunk_tmp):
             raise FileNotFoundError(

--- a/tests/test_dim_key_rename.py
+++ b/tests/test_dim_key_rename.py
@@ -97,9 +97,12 @@ def test_remap_horiz_uses_cmip_x_dim(monkeypatch):
     config.set('cmip_dataset', 'x_dim', 'x')
 
     called = {}
+    # The CMIP (POP) grid has 2D longitude, which must take the
+    # add_periodic_lon (regional) branch rather than the 1D global branch.
+    lon2d = np.array([[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]])
     ds = xr.Dataset(
         {'ct': (('time', 'y', 'x'), np.zeros((1, 2, 3), dtype=np.float32))},
-        coords={'lon': ('x', np.array([0.0, 1.0, 2.0]))},
+        coords={'lon': (('y', 'x'), lon2d)},
     )
 
     def fake_read_dataset(*args, **kwargs):

--- a/tests/test_final_staging_clim.py
+++ b/tests/test_final_staging_clim.py
@@ -1,0 +1,44 @@
+import os
+
+import xarray as xr
+from mpas_tools.config import MpasConfigParser
+
+from i7aof.convert.ct_sa_to_thetao_so import _publish_final_climatology
+
+
+def _config(tmp_path):
+    config = MpasConfigParser()
+    config.set('workdir', 'base_dir', str(tmp_path))
+    config.set('output', 'version', 'v4')
+    config.set('climatology', 'climatology_start_year', '1972')
+    config.set('climatology', 'climatology_end_year', '2024')
+    return config
+
+
+def test_publish_ct_and_sa_to_final(tmp_path):
+    config = _config(tmp_path)
+    src_dir = tmp_path / 'extrap'
+    src_dir.mkdir()
+    published = {}
+    for var in ('ct', 'sa'):
+        src = src_dir / f'OI_Climatology_ismip8km_60m_{var}_extrap.nc'
+        xr.Dataset({var: ('x', [0.0])}).to_netcdf(str(src))
+        _publish_final_climatology(
+            config=config, clim_name='clim_test', var=var, in_path=str(src)
+        )
+        expected = os.path.join(
+            str(tmp_path),
+            'final',
+            'AIS',
+            'obs',
+            'ocean',
+            'climatology',
+            'clim_test',
+            var,
+            'v4',
+            f'{var}_AIS_obs_ocean_climatology_clim_test_v4_1972-2024.nc',
+        )
+        published[var] = expected
+
+    for var, path in published.items():
+        assert os.path.exists(path), f'{var} not staged at {path}'

--- a/tests/test_remap_periodic.py
+++ b/tests/test_remap_periodic.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pytest
+import xarray as xr
+from mpas_tools.config import MpasConfigParser
+
+from i7aof.remap import drop_duplicate_lon
+from i7aof.remap.shared import _remap_horiz
+
+
+def _lon_dataset(lon, units='degrees_east'):
+    """A small dataset with a 1D longitude coordinate and a data var."""
+    data = np.arange(lon.size, dtype=np.float32)
+    ds = xr.Dataset(
+        {'field': ('lon', data)},
+        coords={'lon': ('lon', lon)},
+    )
+    ds['lon'].attrs['units'] = units
+    return ds
+
+
+def test_drop_duplicate_lon_removes_seam_column():
+    # -180..180 inclusive: the -180 and +180 columns are duplicates
+    lon = np.linspace(-180.0, 180.0, 5)  # -180, -90, 0, 90, 180
+    ds = _lon_dataset(lon)
+    out = drop_duplicate_lon(ds, lon_var='lon')
+    assert out.sizes['lon'] == 4
+    np.testing.assert_array_equal(out['lon'].values, lon[:-1])
+    # data var is trimmed consistently
+    np.testing.assert_array_equal(out['field'].values, np.arange(4))
+
+
+def test_drop_duplicate_lon_keeps_non_duplicate():
+    # spans less than a full circle: nothing should be dropped
+    lon = np.linspace(-180.0, 90.0, 4)
+    ds = _lon_dataset(lon)
+    out = drop_duplicate_lon(ds, lon_var='lon')
+    assert out.sizes['lon'] == 4
+    np.testing.assert_array_equal(out['lon'].values, lon)
+
+
+def test_drop_duplicate_lon_handles_radians():
+    lon = np.linspace(-np.pi, np.pi, 5)
+    ds = _lon_dataset(lon, units='radians')
+    out = drop_duplicate_lon(ds, lon_var='lon')
+    assert out.sizes['lon'] == 4
+
+
+def test_drop_duplicate_lon_rejects_2d():
+    lon2d = np.array([[0.0, 1.0], [0.0, 1.0]])
+    ds = xr.Dataset(coords={'lon': (('y', 'x'), lon2d)})
+    with pytest.raises(ValueError, match='1 dimension'):
+        drop_duplicate_lon(ds, lon_var='lon')
+
+
+def test_remap_horiz_1d_drops_duplicate_and_forces_global(monkeypatch):
+    """A 1D global climatology grid is conditioned and forced global."""
+    config = MpasConfigParser()
+    config.set('remap', 'method', 'bilinear')
+    config.set('remap', 'threshold', '1e-3')
+
+    lon = np.linspace(-180.0, 180.0, 5)
+    ds = xr.Dataset(
+        {'ct': (('time', 'lat', 'lon'), np.zeros((1, 2, 5), np.float32))},
+        coords={'lon': ('lon', lon), 'lat': ('lat', np.array([-80.0, -70.0]))},
+    )
+    ds['lon'].attrs['units'] = 'degrees_east'
+
+    captured = {}
+
+    monkeypatch.setattr('i7aof.remap.shared.read_dataset', lambda *a, **k: ds)
+
+    def fake_add_periodic_lon(*args, **kwargs):
+        captured['add_periodic_called'] = True
+        return kwargs.get('ds', args[0] if args else None)
+
+    monkeypatch.setattr(
+        'i7aof.remap.shared.add_periodic_lon', fake_add_periodic_lon
+    )
+
+    def fake_mask(**kwargs):
+        captured['mask_regional'] = kwargs['regional']
+        captured['mask_nlon'] = kwargs['ds'].sizes['lon']
+        return xr.Dataset()
+
+    def fake_data(**kwargs):
+        captured['data_regional'] = kwargs['regional']
+        return [xr.Dataset({'ct': kwargs['ds']['ct']})]
+
+    monkeypatch.setattr('i7aof.remap.shared._build_and_remap_mask', fake_mask)
+    monkeypatch.setattr('i7aof.remap.shared._remap_data_variables', fake_data)
+    monkeypatch.setattr(
+        'i7aof.remap.shared._validate_z_extrap', lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        'i7aof.remap.shared._concat_chunks', lambda chunks: chunks[0]
+    )
+    monkeypatch.setattr(
+        'i7aof.remap.shared._finalize_and_write', lambda **k: None
+    )
+
+    _remap_horiz(
+        config=config,
+        in_filename='ignored.nc',
+        out_filename='ignored_out.nc',
+        model_prefix='clim',
+        tmpdir='.',
+        logger=None,
+        has_fill_values=['ct'],
+        lat_var='lat',
+        lon_var='lon',
+        x_dim='lon',
+    )
+
+    # 1D path: duplicate seam column dropped (5 -> 4), source forced global,
+    # and the 2D periodic workaround is not used.
+    assert captured['mask_nlon'] == 4
+    assert captured['mask_regional'] is False
+    assert captured['data_regional'] is False
+    assert 'add_periodic_called' not in captured

--- a/tests/test_remap_surface_mask.py
+++ b/tests/test_remap_surface_mask.py
@@ -1,0 +1,65 @@
+import numpy as np
+import xarray as xr
+
+from i7aof.io import write_netcdf
+from i7aof.remap.shared import _prepare_vert_coords_and_mask
+
+
+def _make_preprocessed(tmp_path):
+    """A tiny climatology-like preprocessed file.
+
+    ``lev`` is positive-up and descending (surface at index 0), matching
+    what ``_preprocess_climatology_input`` produces from pressures.
+    Column (lat=0, lon=0) has a fill value at the surface but valid data
+    below; column (lat=0, lon=1) is fully valid.
+    """
+    lev = np.array([-5.0, -50.0, -500.0])  # surface (max z) is index 0
+    lev_bnds = np.array([[0.0, -27.5], [-27.5, -275.0], [-275.0, -725.0]])
+    ct = np.array(
+        [
+            [[np.nan, 1.0]],  # surface: fill at lon=0, valid at lon=1
+            [[2.0, 2.0]],
+            [[3.0, 3.0]],
+        ]
+    )
+    sa = np.full_like(ct, 34.0)
+    ds = xr.Dataset(
+        data_vars={
+            'ct': (('lev', 'lat', 'lon'), ct),
+            'sa': (('lev', 'lat', 'lon'), sa),
+            'lev_bnds': (('lev', 'd2'), lev_bnds),
+        },
+        coords={
+            'lev': ('lev', lev),
+            'lat': ('lat', np.array([0.0])),
+            'lon': ('lon', np.array([0.0, 1.0])),
+        },
+    )
+    ds['lev'].attrs = {'units': 'm', 'positive': 'up'}
+    path = tmp_path / 'preprocessed.nc'
+    write_netcdf(ds, str(path))
+    return str(path)
+
+
+def test_surface_mask_invalidates_whole_column(tmp_path):
+    in_filename = _make_preprocessed(tmp_path)
+    _, _, src_valid = _prepare_vert_coords_and_mask(
+        in_filename, ['ct', 'sa'], mask_from_surface=True
+    )
+    # Column with a surface fill value is fully invalid at every level.
+    assert not bool(src_valid.isel(lat=0, lon=0).any())
+    # Fully valid column stays valid everywhere.
+    assert bool(src_valid.isel(lat=0, lon=1).all())
+
+
+def test_without_surface_mask_keeps_subsurface(tmp_path):
+    in_filename = _make_preprocessed(tmp_path)
+    _, _, src_valid = _prepare_vert_coords_and_mask(
+        in_filename, ['ct', 'sa'], mask_from_surface=False
+    )
+    col = src_valid.isel(lat=0, lon=0).values
+    surface_idx = int(np.asarray(src_valid['lev'].values).argmax())
+    # Surface fill stays invalid, but the subsurface levels remain valid.
+    assert not bool(col[surface_idx])
+    subsurface = np.delete(col, surface_idx)
+    assert subsurface.all()


### PR DESCRIPTION
This fixes a small issue with remapping at the dateline for 1D lat/lon datasets.  We need to drop the redundant periodic column in 1D lat/lon datasets (e.g. the climatology) and to supply `regional=False` or `regional=True`.

This PR also masks climatology columns lacking surface data. The observational climatology represents some ice-shelf-cavity and coastal columns with valid data at depth but a fill value at the surface. These spurious columns get remapped and extrapolated into the thermal forcing, producing striping (e.g. in the Ross cavity).

Finally, this PR stages climatology ct and sa as final outputs. Previously only tf (and thetao/so) were published to the final directory for the observational climatology; ct and sa were never staged. Publish the extrapolated ct and sa files alongside thetao/so so all five fields (ct, sa, tf, thetao, so) appear under final/AIS/obs/ocean/climatology/<clim>/.